### PR TITLE
feat: support ytmusic daily recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Please make sure to compatible with [FeelUOwn](https://github.com/feeluown/FeelU
 - [x] Get song detail by id
 - [ ] Add/remove song from a playlist
 - [ ] Upload songs to cloud
+- [x] Daily recommendation page (songs/playlists)
 - [ ] Discovering page
 
 ## Changelog

--- a/fuo_ytmusic/models.py
+++ b/fuo_ytmusic/models.py
@@ -236,17 +236,36 @@ class YtmusicHistorySong(YtmusicLibrarySong):
     played: str  # 上次播放 eg November 2021
 
 
-class YtmusicHomeSong(YtmusicSearchSong):
-    class Album(YtmusicSearchSong.Album):
-        pass
+class YtmusicHomeSong(BaseModel, YtmusicCoverMixin, YtmusicArtistsMixin, YtmusicDurationMixin):
+    """Home feed song item.
 
+    Keep this model independent from YtmusicSearchSong:
+    home payload does not guarantee full search-song fields.
+    """
+
+    class Album(BaseModel):
+        id: str
+        name: str
+
+    title: str
+    videoId: str
+    album: Album = Field(default_factory=lambda: YtmusicHomeSong.Album(id="", name=""))
+    duration: str = "0:00"
     category: str = "Songs"
     resultType: str = "song"
-    album: Album = Field(default_factory=lambda: YtmusicHomeSong.Album(id="", name=""))
-    feedbackTokens: dict = Field(default_factory=dict)
-    isAvailable: bool = True
-    isExplicit: bool = False
-    duration: str = "0:00"
+
+    def v2_brief_model(self) -> BriefSongModel:
+        song = BriefSongModel(
+            identifier=self.videoId or "",
+            source=self.source,
+            title=self.title,
+            artists_name=self.artists_name,
+            album_name=self.album.name if self.album else "",
+            duration_ms=self.duration,
+        )
+        if not song.identifier:
+            song.state = ModelState.not_exists
+        return song
 
 
 class YtmusicSearchAlbum(YtmusicSearchBase, YtmusicCoverMixin, YtmusicArtistsMixin):

--- a/fuo_ytmusic/provider.py
+++ b/fuo_ytmusic/provider.py
@@ -211,6 +211,100 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
                 user_fav_playlists.append(playlist)
         return user_fav_playlists
 
+    def rec_list_daily_songs(self) -> List[SongModel]:
+        songs: List[SongModel] = []
+        seen_video_ids = set()
+        try:
+            sections = self.service.home_sections(limit=6)
+        except Exception as e:
+            logger.warning("fetch ytmusic home sections failed: %s", e)
+            return songs
+
+        for section in sections or []:
+            for content in section.get("contents") or []:
+                video_id = content.get("videoId")
+                artists = content.get("artists")
+                if not video_id or not artists:
+                    continue
+                if video_id in seen_video_ids:
+                    continue
+                seen_video_ids.add(video_id)
+
+                album = content.get("album") or {"id": "", "name": ""}
+                song_payload = {
+                    "category": "Songs",
+                    "resultType": "song",
+                    "title": content.get("title") or "",
+                    "album": {
+                        "id": album.get("id") or "",
+                        "name": album.get("name") or "",
+                    },
+                    "feedbackTokens": {},
+                    "videoId": video_id,
+                    "isAvailable": True,
+                    "isExplicit": bool(content.get("isExplicit", False)),
+                    "artists": artists,
+                    "thumbnails": content.get("thumbnails") or [],
+                    "duration": content.get("duration") or "0:00",
+                }
+                try:
+                    songs.append(YtmusicWatchPlaylistSong(**song_payload).v2_model())
+                except Exception as e:
+                    logger.warning(
+                        "skip invalid home song item(%s): %s",
+                        video_id,
+                        e,
+                    )
+        return songs
+
+    def rec_list_daily_playlists(self) -> List[PlaylistModel]:
+        playlists: List[PlaylistModel] = []
+        seen_playlist_ids = set()
+        try:
+            sections = self.service.home_sections(limit=6)
+        except Exception as e:
+            logger.warning("fetch ytmusic home sections failed: %s", e)
+            return playlists
+
+        for section in sections or []:
+            for content in section.get("contents") or []:
+                playlist_id = content.get("playlistId")
+                title = content.get("title")
+                if not playlist_id or not title:
+                    continue
+                if playlist_id in seen_playlist_ids:
+                    continue
+                seen_playlist_ids.add(playlist_id)
+
+                author = content.get("author") or []
+                creator_name = "/".join(
+                    [item.get("name") for item in author if item.get("name")]
+                )
+                thumbnails = content.get("thumbnails") or []
+                cover = ""
+                if thumbnails:
+                    cover = thumbnails[-1].get("url") or ""
+
+                try:
+                    playlists.append(
+                        PlaylistModel(
+                            identifier=playlist_id,
+                            source=self.meta.identifier,
+                            name=title,
+                            creator_name=creator_name,
+                            cover=cover,
+                            description=content.get("description") or "",
+                            play_count=int(content.get("count") or -1),
+                        )
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "skip invalid home playlist item(%s): %s",
+                        playlist_id,
+                        e,
+                    )
+        return playlists
+
     def create_playlist(
         self,
         title: str,

--- a/fuo_ytmusic/provider.py
+++ b/fuo_ytmusic/provider.py
@@ -5,6 +5,7 @@ from feeluown.excs import NoUserLoggedIn, ProviderIOError
 from feeluown.library import (
     AbstractProvider,
     BriefPlaylistModel,
+    BriefSongModel,
     BriefUserModel,
     BriefVideoModel,
     ModelNotFound,
@@ -235,8 +236,8 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
                 if isinstance(content, dict):
                     yield content
 
-    def rec_list_daily_songs(self) -> List[SongModel]:
-        songs: List[SongModel] = []
+    def rec_list_daily_songs(self) -> List[BriefSongModel]:
+        songs: List[BriefSongModel] = []
         seen_video_ids = set()
         sections = self._get_daily_home_sections(limit=6)
 
@@ -245,7 +246,7 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
             if not video_id or video_id in seen_video_ids:
                 continue
             try:
-                song = YtmusicHomeSong(**content).v2_model()
+                song = YtmusicHomeSong(**content).v2_brief_model()
             except Exception as e:
                 logger.warning(
                     "skip invalid home song item(%s): %s",

--- a/fuo_ytmusic/service.py
+++ b/fuo_ytmusic/service.py
@@ -311,6 +311,9 @@ class YtmusicService(metaclass=Singleton):
         )
         return [YtmusicDispatcher.search_result_dispatcher(**data) for data in response]
 
+    def home_sections(self, limit: int = 6):
+        return self.api.get_home(limit)
+
     def get_current_account_info(self) -> dict:
         return self._profile_manager.get_current_account_info()
 

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -1,0 +1,98 @@
+from fuo_ytmusic.provider import YtmusicProvider
+
+
+def _build_provider_with_home_sections(sections):
+    provider = YtmusicProvider()
+
+    class _ServiceStub:
+        def home_sections(self, limit=6):
+            assert limit == 6
+            return sections
+
+    provider.service = _ServiceStub()
+    return provider
+
+
+def test_rec_list_daily_songs_extracts_and_deduplicates():
+    sections = [
+        {
+            "title": "Quick picks",
+            "contents": [
+                {
+                    "title": "Song A",
+                    "videoId": "vid-a",
+                    "artists": [{"name": "Artist A", "id": "ar-a"}],
+                    "album": {"name": "Album A", "id": "al-a"},
+                    "thumbnails": [{"url": "https://example.com/a.jpg"}],
+                    "duration": "3:10",
+                },
+                {
+                    "title": "Song A duplicate",
+                    "videoId": "vid-a",
+                    "artists": [{"name": "Artist A", "id": "ar-a"}],
+                    "thumbnails": [{"url": "https://example.com/a2.jpg"}],
+                    "duration": "3:10",
+                },
+                {
+                    "title": "Playlist only",
+                    "playlistId": "PL1",
+                },
+            ],
+        }
+    ]
+    provider = _build_provider_with_home_sections(sections)
+
+    songs = provider.rec_list_daily_songs()
+
+    assert len(songs) == 1
+    assert songs[0].identifier == "vid-a"
+    assert songs[0].title == "Song A"
+
+
+def test_rec_list_daily_playlists_extracts_and_deduplicates():
+    sections = [
+        {
+            "title": "Daily mixes",
+            "contents": [
+                {
+                    "title": "Mix 1",
+                    "playlistId": "PL-1",
+                    "description": "desc",
+                    "count": "12",
+                    "author": [{"name": "YouTube Music"}],
+                    "thumbnails": [{"url": "https://example.com/p1.jpg"}],
+                },
+                {
+                    "title": "Mix 1 duplicate",
+                    "playlistId": "PL-1",
+                    "thumbnails": [{"url": "https://example.com/p1_2.jpg"}],
+                },
+                {
+                    "title": "Not a playlist",
+                    "videoId": "vid-x",
+                    "artists": [{"name": "Artist X", "id": "ar-x"}],
+                },
+            ],
+        }
+    ]
+    provider = _build_provider_with_home_sections(sections)
+
+    playlists = provider.rec_list_daily_playlists()
+
+    assert len(playlists) == 1
+    assert playlists[0].identifier == "PL-1"
+    assert playlists[0].name == "Mix 1"
+    assert playlists[0].creator_name == "YouTube Music"
+
+
+def test_rec_list_daily_returns_empty_when_home_sections_failed():
+    provider = YtmusicProvider()
+
+    class _ServiceStub:
+        def home_sections(self, limit=6):
+            raise RuntimeError("boom")
+
+    provider.service = _ServiceStub()
+
+    assert provider.rec_list_daily_songs() == []
+    assert provider.rec_list_daily_playlists() == []

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -34,6 +34,10 @@ def test_rec_list_daily_songs_extracts_and_deduplicates():
                     "duration": "3:10",
                 },
                 {
+                    "title": "Song B",
+                    "videoId": "vid-b",
+                },
+                {
                     "title": "Playlist only",
                     "playlistId": "PL1",
                 },
@@ -44,9 +48,9 @@ def test_rec_list_daily_songs_extracts_and_deduplicates():
 
     songs = provider.rec_list_daily_songs()
 
-    assert len(songs) == 1
-    assert songs[0].identifier == "vid-a"
+    assert [song.identifier for song in songs] == ["vid-a", "vid-b"]
     assert songs[0].title == "Song A"
+    assert songs[1].title == "Song B"
 
 
 def test_rec_list_daily_playlists_extracts_and_deduplicates():
@@ -58,7 +62,7 @@ def test_rec_list_daily_playlists_extracts_and_deduplicates():
                     "title": "Mix 1",
                     "playlistId": "PL-1",
                     "description": "desc",
-                    "count": "12",
+                    "count": "1,234 songs",
                     "author": [{"name": "YouTube Music"}],
                     "thumbnails": [{"url": "https://example.com/p1.jpg"}],
                 },
@@ -83,6 +87,7 @@ def test_rec_list_daily_playlists_extracts_and_deduplicates():
     assert playlists[0].identifier == "PL-1"
     assert playlists[0].name == "Mix 1"
     assert playlists[0].creator_name == "YouTube Music"
+    assert playlists[0].play_count == 1234
 
 
 def test_rec_list_daily_returns_empty_when_home_sections_failed():

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -1,3 +1,5 @@
+from feeluown.library import BriefSongModel
+
 from fuo_ytmusic.provider import YtmusicProvider
 
 
@@ -48,6 +50,7 @@ def test_rec_list_daily_songs_extracts_and_deduplicates():
 
     songs = provider.rec_list_daily_songs()
 
+    assert all(isinstance(song, BriefSongModel) for song in songs)
     assert [song.identifier for song in songs] == ["vid-a", "vid-b"]
     assert songs[0].title == "Song A"
     assert songs[1].title == "Song B"


### PR DESCRIPTION
## Summary
- Add `home_sections(limit=6)` in service as a thin wrapper of `ytmusicapi.get_home()`.
- Implement `rec_list_daily_songs` by extracting song-like items from home sections and deduplicating by `videoId`.
- Implement `rec_list_daily_playlists` by extracting playlist items from home sections and deduplicating by `playlistId`.
- Keep recommendation behavior resilient: invalid items are skipped and full fetch failures return empty lists.
- Update roadmap note for daily recommendation support.

## Testing
- [x] `uv run ruff check fuo_ytmusic/provider.py fuo_ytmusic/service.py tests/test_recommendation.py`
- [x] `uv run pytest tests/test_recommendation.py tests/test_service.py tests/test_profile.py`
- [x] Manual smoke test in FeelUOwn GUI (daily recommendation page works)
