### PR TITLE
feat: support sectioned recommendation collections

### DIFF
--- a/fuo_ytmusic/home_recommendation.py
+++ b/fuo_ytmusic/home_recommendation.py
@@ -1,0 +1,203 @@
+import logging
+from typing import List, Optional, Sequence, Tuple
+
+from feeluown.library import (
+    BriefAlbumModel,
+    BriefSongModel,
+    BriefVideoModel,
+    Collection,
+    CollectionType,
+    PlaylistModel,
+)
+
+from fuo_ytmusic.models import YtmusicHomePlaylist, YtmusicHomeSong, YtmusicSearchAlbum
+
+logger = logging.getLogger(__name__)
+
+
+class YtmusicHomeRecommendationBuilder:
+    DEFAULT_SECTION_TITLE = "Recommendations"
+    TYPE_TITLE_SUFFIXES = {
+        CollectionType.only_songs: "Songs",
+        CollectionType.only_playlists: "Playlists",
+        CollectionType.only_albums: "Albums",
+        CollectionType.only_videos: "Videos",
+    }
+
+    def __init__(self, source: str):
+        self._source = source
+
+    @staticmethod
+    def normalize_limit(limit: Optional[int], default_limit: int) -> int:
+        if limit is None:
+            return default_limit
+        try:
+            normalized = int(limit)
+        except (TypeError, ValueError):
+            return default_limit
+        return normalized if normalized > 0 else default_limit
+
+    def build_collections(self, sections: Sequence[dict]) -> List[Collection]:
+        collections: List[Collection] = []
+        for section in sections or []:
+            if not isinstance(section, dict):
+                continue
+            contents = section.get("contents")
+            if not isinstance(contents, list):
+                continue
+
+            section_title = section.get("title") or self.DEFAULT_SECTION_TITLE
+            typed_collections = self._build_typed_collections(contents)
+            if not typed_collections:
+                continue
+            if len(typed_collections) == 1:
+                section_type, models = typed_collections[0]
+                collections.append(
+                    Collection(name=section_title, type_=section_type, models=models)
+                )
+                continue
+            for section_type, models in typed_collections:
+                suffix = self.TYPE_TITLE_SUFFIXES[section_type]
+                collections.append(
+                    Collection(
+                        name=f"{section_title} · {suffix}",
+                        type_=section_type,
+                        models=models,
+                    )
+                )
+        return collections
+
+    def _build_typed_collections(
+        self, contents: Sequence[dict]
+    ) -> List[Tuple[CollectionType, list]]:
+        type_builder_pairs = [
+            (CollectionType.only_songs, self._build_home_songs),
+            (CollectionType.only_playlists, self._build_home_playlists),
+            (CollectionType.only_albums, self._build_home_albums),
+            (CollectionType.only_videos, self._build_home_videos),
+        ]
+        collections = []
+        for section_type, builder in type_builder_pairs:
+            models = builder(contents)
+            if models:
+                collections.append((section_type, models))
+        return collections
+
+    @staticmethod
+    def _iter_valid_contents(contents: Sequence[dict]):
+        for content in contents or []:
+            if isinstance(content, dict):
+                yield content
+
+    @staticmethod
+    def _detect_home_item_type(content: dict):
+        playlist_id = content.get("playlistId")
+        video_id = content.get("videoId")
+        artists = content.get("artists")
+        album = content.get("album")
+
+        if playlist_id and not video_id:
+            # Includes watch playlist and mix/radio-like playlist rows.
+            return CollectionType.only_playlists
+        if video_id:
+            # Some cards carry both videoId and playlistId. If there is no song
+            # metadata, treat them as playlist-like mix cards.
+            if playlist_id and not artists and not album:
+                return CollectionType.only_playlists
+            # YTMusic home videos usually include a view-count field.
+            if content.get("views"):
+                return CollectionType.only_videos
+            return CollectionType.only_songs
+        if playlist_id:
+            return CollectionType.only_playlists
+        if content.get("browseId") and content.get("artists") is not None:
+            # Artists also carry browseId; require artists field to identify albums.
+            return CollectionType.only_albums
+        return None
+
+    def _build_home_songs(self, contents: Sequence[dict]) -> List[BriefSongModel]:
+        songs: List[BriefSongModel] = []
+        seen_video_ids = set()
+        for content in self._iter_valid_contents(contents):
+            if self._detect_home_item_type(content) != CollectionType.only_songs:
+                continue
+            video_id = content.get("videoId")
+            if not video_id or video_id in seen_video_ids:
+                continue
+            try:
+                song = YtmusicHomeSong(**content).v2_brief_model()
+            except Exception as e:
+                logger.warning("skip invalid home song item(%s): %s", video_id, e)
+                continue
+            if not song.identifier:
+                continue
+            seen_video_ids.add(song.identifier)
+            songs.append(song)
+        return songs
+
+    def _build_home_playlists(self, contents: Sequence[dict]) -> List[PlaylistModel]:
+        playlists: List[PlaylistModel] = []
+        seen_playlist_ids = set()
+        for content in self._iter_valid_contents(contents):
+            if self._detect_home_item_type(content) != CollectionType.only_playlists:
+                continue
+            playlist_id = content.get("playlistId")
+            if not playlist_id or playlist_id in seen_playlist_ids:
+                continue
+            try:
+                playlist = YtmusicHomePlaylist(**content).v2_model()
+            except Exception as e:
+                logger.warning("skip invalid home playlist item(%s): %s", playlist_id, e)
+                continue
+            if not playlist.identifier:
+                continue
+            seen_playlist_ids.add(playlist.identifier)
+            playlists.append(playlist)
+        return playlists
+
+    def _build_home_albums(self, contents: Sequence[dict]) -> List[BriefAlbumModel]:
+        albums: List[BriefAlbumModel] = []
+        seen_browse_ids = set()
+        for content in self._iter_valid_contents(contents):
+            if self._detect_home_item_type(content) != CollectionType.only_albums:
+                continue
+            browse_id = content.get("browseId")
+            if not browse_id or browse_id in seen_browse_ids:
+                continue
+            try:
+                album = YtmusicSearchAlbum(**content).v2_brief_model()
+            except Exception as e:
+                logger.warning("skip invalid home album item(%s): %s", browse_id, e)
+                continue
+            if not album.identifier:
+                continue
+            seen_browse_ids.add(album.identifier)
+            albums.append(album)
+        return albums
+
+    def _build_home_videos(self, contents: Sequence[dict]) -> List[BriefVideoModel]:
+        videos: List[BriefVideoModel] = []
+        seen_video_ids = set()
+        for content in self._iter_valid_contents(contents):
+            if self._detect_home_item_type(content) != CollectionType.only_videos:
+                continue
+            video_id = content.get("videoId")
+            if not video_id or video_id in seen_video_ids:
+                continue
+            artists = content.get("artists")
+            artists_name = " / ".join(
+                artist.get("name", "")
+                for artist in (artists or [])
+                if isinstance(artist, dict) and artist.get("name")
+            )
+            videos.append(
+                BriefVideoModel(
+                    identifier=video_id,
+                    source=self._source,
+                    title=content.get("title") or "",
+                    artists_name=artists_name,
+                    duration_ms=content.get("duration") or "",
+                )
+            )
+            seen_video_ids.add(video_id)
+        return videos

--- a/fuo_ytmusic/provider.py
+++ b/fuo_ytmusic/provider.py
@@ -4,10 +4,13 @@ from typing import List, Optional
 from feeluown.excs import NoUserLoggedIn, ProviderIOError
 from feeluown.library import (
     AbstractProvider,
+    BriefAlbumModel,
     BriefPlaylistModel,
     BriefSongModel,
     BriefUserModel,
     BriefVideoModel,
+    Collection,
+    CollectionType,
     ModelNotFound,
     PlaylistModel,
     ProviderV2,
@@ -28,6 +31,7 @@ from fuo_ytmusic.models import (
     Categories,
     YtmusicHomePlaylist,
     YtmusicHomeSong,
+    YtmusicSearchAlbum,
     YtmusicWatchPlaylistSong,
 )
 from fuo_ytmusic.service import YtmusicPrivacyStatus, YtmusicService, YtmusicType
@@ -36,6 +40,8 @@ logger = logging.getLogger(__name__)
 
 
 class YtmusicProvider(AbstractProvider, ProviderV2):
+    HOME_SECTION_LIMIT = 12
+
     def __init__(self):
         super(YtmusicProvider, self).__init__()
         self.service: YtmusicService = YtmusicService()
@@ -217,7 +223,7 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
                 user_fav_playlists.append(playlist)
         return user_fav_playlists
 
-    def _get_daily_home_sections(self, limit: int = 6):
+    def _get_daily_home_sections(self, limit: int = HOME_SECTION_LIMIT):
         try:
             return self.service.home_sections(limit=limit)
         except Exception as e:
@@ -236,12 +242,52 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
                 if isinstance(content, dict):
                     yield content
 
-    def rec_list_daily_songs(self) -> List[BriefSongModel]:
+    @classmethod
+    def _normalize_home_limit(cls, limit: Optional[int]) -> int:
+        if limit is None:
+            return cls.HOME_SECTION_LIMIT
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            return cls.HOME_SECTION_LIMIT
+        return limit if limit > 0 else cls.HOME_SECTION_LIMIT
+
+    @staticmethod
+    def _detect_home_item_type(content):
+        if not isinstance(content, dict):
+            return None
+        playlist_id = content.get("playlistId")
+        video_id = content.get("videoId")
+        artists = content.get("artists")
+        album = content.get("album")
+
+        if playlist_id and not video_id:
+            # Includes watch playlist and mix/radio-like playlist rows.
+            return CollectionType.only_playlists
+
+        if content.get("videoId"):
+            # Some cards may carry both videoId and playlistId; treat cards
+            # without artist/album metadata as playlist-like entries.
+            if playlist_id and not artists and not album:
+                return CollectionType.only_playlists
+            # YTMusic home videos usually carry views.
+            if content.get("views"):
+                return CollectionType.only_videos
+            return CollectionType.only_songs
+        if playlist_id:
+            return CollectionType.only_playlists
+        if content.get("browseId") and content.get("artists") is not None:
+            # Artists also carry browseId; require artists field to identify albums.
+            return CollectionType.only_albums
+        return None
+
+    @classmethod
+    def _build_home_songs(cls, contents):
         songs: List[BriefSongModel] = []
         seen_video_ids = set()
-        sections = self._get_daily_home_sections(limit=6)
-
-        for content in self._iter_home_contents(sections):
+        for content in contents:
+            if cls._detect_home_item_type(content) != CollectionType.only_songs:
+                continue
             video_id = content.get("videoId")
             if not video_id or video_id in seen_video_ids:
                 continue
@@ -260,12 +306,13 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
             songs.append(song)
         return songs
 
-    def rec_list_daily_playlists(self) -> List[PlaylistModel]:
+    @classmethod
+    def _build_home_playlists(cls, contents):
         playlists: List[PlaylistModel] = []
         seen_playlist_ids = set()
-        sections = self._get_daily_home_sections(limit=6)
-
-        for content in self._iter_home_contents(sections):
+        for content in contents:
+            if cls._detect_home_item_type(content) != CollectionType.only_playlists:
+                continue
             playlist_id = content.get("playlistId")
             if not playlist_id or playlist_id in seen_playlist_ids:
                 continue
@@ -282,6 +329,139 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
                 continue
             seen_playlist_ids.add(playlist.identifier)
             playlists.append(playlist)
+        return playlists
+
+    @classmethod
+    def _build_home_albums(cls, contents):
+        albums: List[BriefAlbumModel] = []
+        seen_browse_ids = set()
+        for content in contents:
+            if cls._detect_home_item_type(content) != CollectionType.only_albums:
+                continue
+            browse_id = content.get("browseId")
+            if not browse_id or browse_id in seen_browse_ids:
+                continue
+            try:
+                album = YtmusicSearchAlbum(**content).v2_brief_model()
+            except Exception as e:
+                logger.warning(
+                    "skip invalid home album item(%s): %s",
+                    browse_id,
+                    e,
+                )
+                continue
+            if not album.identifier:
+                continue
+            seen_browse_ids.add(album.identifier)
+            albums.append(album)
+        return albums
+
+    @classmethod
+    def _build_home_videos(cls, contents):
+        videos: List[BriefVideoModel] = []
+        seen_video_ids = set()
+        for content in contents:
+            if cls._detect_home_item_type(content) != CollectionType.only_videos:
+                continue
+            video_id = content.get("videoId")
+            if not video_id or video_id in seen_video_ids:
+                continue
+            artists = content.get("artists")
+            artists_name = " / ".join(
+                artist.get("name", "")
+                for artist in (artists or [])
+                if isinstance(artist, dict) and artist.get("name")
+            )
+            videos.append(
+                BriefVideoModel(
+                    identifier=video_id,
+                    source=cls.meta.identifier,
+                    title=content.get("title") or "",
+                    artists_name=artists_name,
+                    duration_ms=content.get("duration") or "",
+                )
+            )
+            seen_video_ids.add(video_id)
+        return videos
+
+    def rec_list_collections(self, limit: Optional[int] = None) -> List[Collection]:
+        collections: List[Collection] = []
+        section_limit = self._normalize_home_limit(limit)
+        sections = self._get_daily_home_sections(limit=section_limit)
+        type_builder_pairs = [
+            (CollectionType.only_songs, self._build_home_songs),
+            (CollectionType.only_playlists, self._build_home_playlists),
+            (CollectionType.only_albums, self._build_home_albums),
+            (CollectionType.only_videos, self._build_home_videos),
+        ]
+        type_title_suffixes = {
+            CollectionType.only_songs: "Songs",
+            CollectionType.only_playlists: "Playlists",
+            CollectionType.only_albums: "Albums",
+            CollectionType.only_videos: "Videos",
+        }
+
+        for section in sections or []:
+            if not isinstance(section, dict):
+                continue
+            contents = section.get("contents")
+            if not isinstance(contents, list):
+                continue
+            section_title = section.get("title") or "Recommendations"
+            section_collections = []
+            for section_type, builder in type_builder_pairs:
+                models = builder(contents)
+                if not models:
+                    continue
+                section_collections.append((section_type, models))
+            if not section_collections:
+                continue
+
+            if len(section_collections) == 1:
+                section_type, models = section_collections[0]
+                collections.append(
+                    Collection(
+                        name=section_title,
+                        type_=section_type,
+                        models=models,
+                    )
+                )
+                continue
+
+            for section_type, models in section_collections:
+                collections.append(
+                    Collection(
+                        name=f"{section_title} · {type_title_suffixes[section_type]}",
+                        type_=section_type,
+                        models=models,
+                    )
+                )
+        return collections
+
+    def rec_list_daily_songs(self) -> List[BriefSongModel]:
+        songs: List[BriefSongModel] = []
+        seen_video_ids = set()
+        for collection in self.rec_list_collections():
+            if collection.type_ != CollectionType.only_songs:
+                continue
+            for song in collection.models:
+                if not song.identifier or song.identifier in seen_video_ids:
+                    continue
+                seen_video_ids.add(song.identifier)
+                songs.append(song)
+        return songs
+
+    def rec_list_daily_playlists(self) -> List[PlaylistModel]:
+        playlists: List[PlaylistModel] = []
+        seen_playlist_ids = set()
+        for collection in self.rec_list_collections():
+            if collection.type_ != CollectionType.only_playlists:
+                continue
+            for playlist in collection.models:
+                if not playlist.identifier or playlist.identifier in seen_playlist_ids:
+                    continue
+                seen_playlist_ids.add(playlist.identifier)
+                playlists.append(playlist)
         return playlists
 
     def create_playlist(

--- a/fuo_ytmusic/provider.py
+++ b/fuo_ytmusic/provider.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 from feeluown.excs import NoUserLoggedIn, ProviderIOError
 from feeluown.library import (
     AbstractProvider,
-    BriefAlbumModel,
     BriefPlaylistModel,
     BriefSongModel,
     BriefUserModel,
@@ -27,11 +26,9 @@ from yt_dlp import DownloadError, YoutubeDL
 
 from fuo_ytmusic.consts import HEADER_FILE
 from fuo_ytmusic.headerfile import get_profile_gaia_id, update_profile_gaia_id
+from fuo_ytmusic.home_recommendation import YtmusicHomeRecommendationBuilder
 from fuo_ytmusic.models import (
     Categories,
-    YtmusicHomePlaylist,
-    YtmusicHomeSong,
-    YtmusicSearchAlbum,
     YtmusicWatchPlaylistSong,
 )
 from fuo_ytmusic.service import YtmusicPrivacyStatus, YtmusicService, YtmusicType
@@ -45,6 +42,9 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
     def __init__(self):
         super(YtmusicProvider, self).__init__()
         self.service: YtmusicService = YtmusicService()
+        self._home_recommendation_builder = YtmusicHomeRecommendationBuilder(
+            source=self.meta.identifier
+        )
         self.current_user_changed = Signal()
         self._user = None
         self._http_proxy = ""
@@ -230,213 +230,12 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
             logger.warning("fetch ytmusic home sections failed: %s", e)
             return []
 
-    @staticmethod
-    def _iter_home_contents(sections):
-        for section in sections or []:
-            if not isinstance(section, dict):
-                continue
-            contents = section.get("contents")
-            if not isinstance(contents, list):
-                continue
-            for content in contents:
-                if isinstance(content, dict):
-                    yield content
-
-    @classmethod
-    def _normalize_home_limit(cls, limit: Optional[int]) -> int:
-        if limit is None:
-            return cls.HOME_SECTION_LIMIT
-        try:
-            limit = int(limit)
-        except (TypeError, ValueError):
-            return cls.HOME_SECTION_LIMIT
-        return limit if limit > 0 else cls.HOME_SECTION_LIMIT
-
-    @staticmethod
-    def _detect_home_item_type(content):
-        if not isinstance(content, dict):
-            return None
-        playlist_id = content.get("playlistId")
-        video_id = content.get("videoId")
-        artists = content.get("artists")
-        album = content.get("album")
-
-        if playlist_id and not video_id:
-            # Includes watch playlist and mix/radio-like playlist rows.
-            return CollectionType.only_playlists
-
-        if content.get("videoId"):
-            # Some cards may carry both videoId and playlistId; treat cards
-            # without artist/album metadata as playlist-like entries.
-            if playlist_id and not artists and not album:
-                return CollectionType.only_playlists
-            # YTMusic home videos usually carry views.
-            if content.get("views"):
-                return CollectionType.only_videos
-            return CollectionType.only_songs
-        if playlist_id:
-            return CollectionType.only_playlists
-        if content.get("browseId") and content.get("artists") is not None:
-            # Artists also carry browseId; require artists field to identify albums.
-            return CollectionType.only_albums
-        return None
-
-    @classmethod
-    def _build_home_songs(cls, contents):
-        songs: List[BriefSongModel] = []
-        seen_video_ids = set()
-        for content in contents:
-            if cls._detect_home_item_type(content) != CollectionType.only_songs:
-                continue
-            video_id = content.get("videoId")
-            if not video_id or video_id in seen_video_ids:
-                continue
-            try:
-                song = YtmusicHomeSong(**content).v2_brief_model()
-            except Exception as e:
-                logger.warning(
-                    "skip invalid home song item(%s): %s",
-                    video_id,
-                    e,
-                )
-                continue
-            if not song.identifier:
-                continue
-            seen_video_ids.add(song.identifier)
-            songs.append(song)
-        return songs
-
-    @classmethod
-    def _build_home_playlists(cls, contents):
-        playlists: List[PlaylistModel] = []
-        seen_playlist_ids = set()
-        for content in contents:
-            if cls._detect_home_item_type(content) != CollectionType.only_playlists:
-                continue
-            playlist_id = content.get("playlistId")
-            if not playlist_id or playlist_id in seen_playlist_ids:
-                continue
-            try:
-                playlist = YtmusicHomePlaylist(**content).v2_model()
-            except Exception as e:
-                logger.warning(
-                    "skip invalid home playlist item(%s): %s",
-                    playlist_id,
-                    e,
-                )
-                continue
-            if not playlist.identifier:
-                continue
-            seen_playlist_ids.add(playlist.identifier)
-            playlists.append(playlist)
-        return playlists
-
-    @classmethod
-    def _build_home_albums(cls, contents):
-        albums: List[BriefAlbumModel] = []
-        seen_browse_ids = set()
-        for content in contents:
-            if cls._detect_home_item_type(content) != CollectionType.only_albums:
-                continue
-            browse_id = content.get("browseId")
-            if not browse_id or browse_id in seen_browse_ids:
-                continue
-            try:
-                album = YtmusicSearchAlbum(**content).v2_brief_model()
-            except Exception as e:
-                logger.warning(
-                    "skip invalid home album item(%s): %s",
-                    browse_id,
-                    e,
-                )
-                continue
-            if not album.identifier:
-                continue
-            seen_browse_ids.add(album.identifier)
-            albums.append(album)
-        return albums
-
-    @classmethod
-    def _build_home_videos(cls, contents):
-        videos: List[BriefVideoModel] = []
-        seen_video_ids = set()
-        for content in contents:
-            if cls._detect_home_item_type(content) != CollectionType.only_videos:
-                continue
-            video_id = content.get("videoId")
-            if not video_id or video_id in seen_video_ids:
-                continue
-            artists = content.get("artists")
-            artists_name = " / ".join(
-                artist.get("name", "")
-                for artist in (artists or [])
-                if isinstance(artist, dict) and artist.get("name")
-            )
-            videos.append(
-                BriefVideoModel(
-                    identifier=video_id,
-                    source=cls.meta.identifier,
-                    title=content.get("title") or "",
-                    artists_name=artists_name,
-                    duration_ms=content.get("duration") or "",
-                )
-            )
-            seen_video_ids.add(video_id)
-        return videos
-
     def rec_list_collections(self, limit: Optional[int] = None) -> List[Collection]:
-        collections: List[Collection] = []
-        section_limit = self._normalize_home_limit(limit)
+        section_limit = self._home_recommendation_builder.normalize_limit(
+            limit, self.HOME_SECTION_LIMIT
+        )
         sections = self._get_daily_home_sections(limit=section_limit)
-        type_builder_pairs = [
-            (CollectionType.only_songs, self._build_home_songs),
-            (CollectionType.only_playlists, self._build_home_playlists),
-            (CollectionType.only_albums, self._build_home_albums),
-            (CollectionType.only_videos, self._build_home_videos),
-        ]
-        type_title_suffixes = {
-            CollectionType.only_songs: "Songs",
-            CollectionType.only_playlists: "Playlists",
-            CollectionType.only_albums: "Albums",
-            CollectionType.only_videos: "Videos",
-        }
-
-        for section in sections or []:
-            if not isinstance(section, dict):
-                continue
-            contents = section.get("contents")
-            if not isinstance(contents, list):
-                continue
-            section_title = section.get("title") or "Recommendations"
-            section_collections = []
-            for section_type, builder in type_builder_pairs:
-                models = builder(contents)
-                if not models:
-                    continue
-                section_collections.append((section_type, models))
-            if not section_collections:
-                continue
-
-            if len(section_collections) == 1:
-                section_type, models = section_collections[0]
-                collections.append(
-                    Collection(
-                        name=section_title,
-                        type_=section_type,
-                        models=models,
-                    )
-                )
-                continue
-
-            for section_type, models in section_collections:
-                collections.append(
-                    Collection(
-                        name=f"{section_title} · {type_title_suffixes[section_type]}",
-                        type_=section_type,
-                        models=models,
-                    )
-                )
-        return collections
+        return self._home_recommendation_builder.build_collections(sections)
 
     def rec_list_daily_songs(self) -> List[BriefSongModel]:
         songs: List[BriefSongModel] = []

--- a/fuo_ytmusic/service.py
+++ b/fuo_ytmusic/service.py
@@ -325,7 +325,7 @@ class YtmusicService(metaclass=Singleton):
     def _home_sections_cached(self, limit: int, account_key: str):
         return self.api.get_home(limit)
 
-    def home_sections(self, limit: int = 6):
+    def home_sections(self, limit: int = 12):
         return self._home_sections_cached(limit, self._daily_home_cache_key())
 
     def get_current_account_info(self) -> dict:

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -1,14 +1,15 @@
-from feeluown.library import BriefSongModel
+from feeluown.library import BriefSongModel, CollectionType
 
 from fuo_ytmusic.provider import YtmusicProvider
 
 
-def _build_provider_with_home_sections(sections):
+def _build_provider_with_home_sections(sections, expected_limit=None):
     provider = YtmusicProvider()
+    expected_limit = expected_limit or provider.HOME_SECTION_LIMIT
 
     class _ServiceStub:
-        def home_sections(self, limit=6):
-            assert limit == 6
+        def home_sections(self, limit=expected_limit):
+            assert limit == expected_limit
             return sections
 
     provider.service = _ServiceStub()
@@ -56,6 +57,91 @@ def test_rec_list_daily_songs_extracts_and_deduplicates():
     assert songs[1].title == "Song B"
 
 
+def test_rec_list_collections_preserves_sections():
+    sections = [
+        {
+            "title": "Quick picks",
+            "contents": [
+                {
+                    "title": "Song A",
+                    "videoId": "vid-a",
+                    "artists": [{"name": "Artist A", "id": "ar-a"}],
+                },
+                {
+                    "title": "Song B",
+                    "videoId": "vid-b",
+                },
+            ],
+        },
+        {
+            "title": "Daily mixes",
+            "contents": [
+                {
+                    "title": "Mix 1",
+                    "playlistId": "PL-1",
+                    "author": [{"name": "YouTube Music"}],
+                }
+            ],
+        },
+        {
+            "title": "Recommended albums",
+            "contents": [
+                {
+                    "title": "Album A",
+                    "browseId": "MPREb_album_a",
+                    "artists": [{"name": "Artist A", "id": "ar-a"}],
+                    "thumbnails": [{"url": "https://example.com/al-a.jpg"}],
+                }
+            ],
+        },
+        {
+            "title": "Recommended videos",
+            "contents": [
+                {
+                    "title": "Video A",
+                    "videoId": "video-a",
+                    "views": "10K",
+                    "artists": [{"name": "Artist A", "id": "ar-a"}],
+                    "duration": "3:20",
+                }
+            ],
+        },
+        {
+            "title": "Mixed for you",
+            "contents": [
+                {
+                    "title": "My Mix",
+                    "playlistId": "RDCLAK5uy_mix_1",
+                    "thumbnails": [{"url": "https://example.com/mix-1.jpg"}],
+                }
+            ],
+        },
+    ]
+    provider = _build_provider_with_home_sections(sections)
+
+    collections = provider.rec_list_collections()
+
+    assert [c.name for c in collections] == [
+        "Quick picks",
+        "Daily mixes",
+        "Recommended albums",
+        "Recommended videos",
+        "Mixed for you",
+    ]
+    assert [c.type_ for c in collections] == [
+        CollectionType.only_songs,
+        CollectionType.only_playlists,
+        CollectionType.only_albums,
+        CollectionType.only_videos,
+        CollectionType.only_playlists,
+    ]
+    assert [m.identifier for m in collections[0].models] == ["vid-a", "vid-b"]
+    assert [m.identifier for m in collections[1].models] == ["PL-1"]
+    assert [m.identifier for m in collections[2].models] == ["MPREb_album_a"]
+    assert [m.identifier for m in collections[3].models] == ["video-a"]
+    assert [m.identifier for m in collections[4].models] == ["RDCLAK5uy_mix_1"]
+
+
 def test_rec_list_daily_playlists_extracts_and_deduplicates():
     sections = [
         {
@@ -93,6 +179,77 @@ def test_rec_list_daily_playlists_extracts_and_deduplicates():
     assert playlists[0].play_count == 1234
 
 
+def test_rec_list_daily_songs_dedup_across_sections():
+    sections = [
+        {
+            "title": "Quick picks A",
+            "contents": [
+                {"title": "Song A", "videoId": "vid-a"},
+                {"title": "Song B", "videoId": "vid-b"},
+            ],
+        },
+        {
+            "title": "Quick picks B",
+            "contents": [
+                {"title": "Song A duplicate", "videoId": "vid-a"},
+                {"title": "Song C", "videoId": "vid-c"},
+            ],
+        },
+    ]
+    provider = _build_provider_with_home_sections(sections)
+
+    songs = provider.rec_list_daily_songs()
+
+    assert [song.identifier for song in songs] == ["vid-a", "vid-b", "vid-c"]
+
+
+def test_rec_list_collections_skips_none_items():
+    sections = [
+        {
+            "title": "Quick picks",
+            "contents": [None, {"title": "Song A", "videoId": "vid-a"}],
+        }
+    ]
+    provider = _build_provider_with_home_sections(sections)
+
+    collections = provider.rec_list_collections()
+
+    assert len(collections) == 1
+    assert collections[0].type_ == CollectionType.only_songs
+    assert [m.identifier for m in collections[0].models] == ["vid-a"]
+
+
+def test_rec_list_collections_supports_mixed_section():
+    sections = [
+        {
+            "title": "For you",
+            "contents": [
+                {"title": "Song A", "videoId": "vid-a"},
+                {
+                    "title": "Mix A",
+                    "playlistId": "RD_mix_a",
+                    "videoId": "seed-video",
+                    # No artists/album -> should be treated as playlist-like mix card.
+                },
+            ],
+        }
+    ]
+    provider = _build_provider_with_home_sections(sections)
+
+    collections = provider.rec_list_collections()
+
+    assert [c.name for c in collections] == [
+        "For you · Songs",
+        "For you · Playlists",
+    ]
+    assert [c.type_ for c in collections] == [
+        CollectionType.only_songs,
+        CollectionType.only_playlists,
+    ]
+    assert [m.identifier for m in collections[0].models] == ["vid-a"]
+    assert [m.identifier for m in collections[1].models] == ["RD_mix_a"]
+
+
 def test_rec_list_daily_returns_empty_when_home_sections_failed():
     provider = YtmusicProvider()
 
@@ -104,3 +261,18 @@ def test_rec_list_daily_returns_empty_when_home_sections_failed():
 
     assert provider.rec_list_daily_songs() == []
     assert provider.rec_list_daily_playlists() == []
+
+
+def test_rec_list_collections_supports_limit_parameter():
+    sections = [
+        {
+            "title": "Quick picks",
+            "contents": [{"title": "Song A", "videoId": "vid-a"}],
+        }
+    ]
+    provider = _build_provider_with_home_sections(sections, expected_limit=3)
+
+    collections = provider.rec_list_collections(limit=3)
+
+    assert len(collections) == 1
+    assert collections[0].type_ == CollectionType.only_songs


### PR DESCRIPTION
## Summary
- add `rec_list_collections(limit=None)` based on `get_home()` sections and keep daily recommendation APIs as compatibility wrappers
- increase default home-section fetch limit to 12 and allow provider-level limit override
- map home sections into typed collections for songs, playlists (including mix), albums, and videos
- split mixed sections into multiple typed collections with suffixed titles (for example `For you · Songs`)
- ignore `None` items in section contents to avoid `NoneType.get` runtime errors

## Testing
- [x] `uv run pytest`
