### PR TITLE
feat: add ytmusic toplist support

### DIFF
--- a/fuo_ytmusic/provider.py
+++ b/fuo_ytmusic/provider.py
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 
 class YtmusicProvider(AbstractProvider, ProviderV2):
     HOME_SECTION_LIMIT = 12
+    # get_charts returns playlist sections under these keys; artists are omitted.
+    TOPLIST_CHART_KEYS = ("daily", "weekly", "videos", "genres")
 
     def __init__(self):
         super(YtmusicProvider, self).__init__()
@@ -262,6 +264,42 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
                 seen_playlist_ids.add(playlist.identifier)
                 playlists.append(playlist)
         return playlists
+
+    def _build_toplist_playlists(self, charts: dict) -> List[BriefPlaylistModel]:
+        toplists: List[BriefPlaylistModel] = []
+        seen_playlist_ids = set()
+        for key in self.TOPLIST_CHART_KEYS:
+            section = charts.get(key)
+            if not isinstance(section, list):
+                continue
+            for item in section:
+                if not isinstance(item, dict):
+                    continue
+                playlist_id = item.get("playlistId")
+                if not playlist_id or playlist_id in seen_playlist_ids:
+                    continue
+                toplists.append(
+                    BriefPlaylistModel(
+                        identifier=playlist_id,
+                        source=self.meta.identifier,
+                        name=item.get("title") or "",
+                    )
+                )
+                seen_playlist_ids.add(playlist_id)
+        return toplists
+
+    def toplist_list(self) -> List[BriefPlaylistModel]:
+        try:
+            charts = self.service.get_charts(country="ZZ")
+        except Exception as e:
+            logger.warning("fetch ytmusic charts failed: %s", e)
+            return []
+        if not isinstance(charts, dict):
+            return []
+        return self._build_toplist_playlists(charts)
+
+    def toplist_get(self, toplist_id) -> PlaylistModel:
+        return self.service.playlist_info(toplist_id).v2_model()
 
     def create_playlist(
         self,

--- a/fuo_ytmusic/service.py
+++ b/fuo_ytmusic/service.py
@@ -31,7 +31,6 @@ from fuo_ytmusic.models import (
     PlaylistInfo,
     PlaylistNestedResult,
     SongInfo,
-    TopCharts,
     UserInfo,
     YtmusicDispatcher,
     YtmusicHistorySong,
@@ -422,14 +421,9 @@ class YtmusicService(metaclass=Singleton):
         return [PlaylistNestedResult(**data) for data in response]
 
     @ttl_cache(maxsize=CACHE_SIZE, ttl=CACHE_TTL)
-    def get_charts(self, country: str = "ZZ") -> TopCharts:
-        # temp workaround for ytmusicapi#236
-        # sees: https://github.com/sigma67/ytmusicapi/issues/236
-        auth = self.api.auth
-        self.api.auth = None
+    def get_charts(self, country: str = "ZZ") -> dict:
         response = self.api.get_charts(country)
-        self.api.auth = auth
-        return TopCharts(**response)
+        return response if isinstance(response, dict) else {}
 
     def library_playlists(
         self, limit: int = GLOBAL_LIMIT

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -113,6 +113,18 @@ class TestService:
         assert ".youtube.com	TRUE	/	TRUE	0	SID	abc" in content
         assert ".google.com	TRUE	/	TRUE	0	HSID	def" in content
 
+    def test_get_charts_returns_raw_dict(self):
+        self.service.get_charts.cache_clear()
+        self.service._api = _ChartsApi(payload={"videos": []})
+
+        assert self.service.get_charts("ZZ") == {"videos": []}
+
+    def test_get_charts_returns_empty_when_payload_invalid(self):
+        self.service.get_charts.cache_clear()
+        self.service._api = _ChartsApi(payload=[{"playlistId": "PL-1"}])
+
+        assert self.service.get_charts("ZZ") == {}
+
 
 class _StubApi:
     def __init__(self, payload):
@@ -133,3 +145,11 @@ class _AuthContextApi:
 
     def get_user_agent(self):
         return self._user_agent
+
+
+class _ChartsApi:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def get_charts(self, *_args, **_kwargs):
+        return self.payload

--- a/tests/test_toplist.py
+++ b/tests/test_toplist.py
@@ -1,0 +1,88 @@
+from feeluown.library import BriefPlaylistModel, PlaylistModel
+
+from fuo_ytmusic.provider import YtmusicProvider
+
+
+def test_toplist_list_extracts_and_deduplicates_playlists():
+    provider = YtmusicProvider()
+    charts = {
+        "daily": [
+            {"title": "Daily A", "playlistId": "PL-daily-a"},
+            {"title": "Daily duplicate", "playlistId": "PL-shared"},
+        ],
+        "weekly": [
+            {"title": "Weekly A", "playlistId": "PL-weekly-a"},
+            {"title": "Weekly duplicate", "playlistId": "PL-shared"},
+        ],
+        "videos": [
+            {"title": "Videos A", "playlistId": "PL-videos-a"},
+            {"title": "Ignore missing id"},
+            None,
+        ],
+        "genres": [
+            {"title": "Genres A", "playlistId": "PL-genres-a"},
+            {"title": "Genres duplicate", "playlistId": "PL-videos-a"},
+        ],
+        "artists": [{"title": "Artist X"}],
+    }
+
+    class _ServiceStub:
+        def get_charts(self, country="ZZ"):
+            assert country == "ZZ"
+            return charts
+
+    provider.service = _ServiceStub()
+
+    toplists = provider.toplist_list()
+
+    assert all(isinstance(each, BriefPlaylistModel) for each in toplists)
+    assert [each.identifier for each in toplists] == [
+        "PL-daily-a",
+        "PL-shared",
+        "PL-weekly-a",
+        "PL-videos-a",
+        "PL-genres-a",
+    ]
+    assert [each.name for each in toplists] == [
+        "Daily A",
+        "Daily duplicate",
+        "Weekly A",
+        "Videos A",
+        "Genres A",
+    ]
+
+
+def test_toplist_list_returns_empty_when_fetch_failed():
+    provider = YtmusicProvider()
+
+    class _ServiceStub:
+        def get_charts(self, country="ZZ"):
+            raise RuntimeError("boom")
+
+    provider.service = _ServiceStub()
+
+    assert provider.toplist_list() == []
+
+
+def test_toplist_get_delegates_to_playlist_info():
+    provider = YtmusicProvider()
+    expected = PlaylistModel(
+        identifier="PL-1",
+        source="ytmusic",
+        name="Toplist A",
+        cover="",
+        description="",
+    )
+
+    class _PlaylistInfoStub:
+        def v2_model(self):
+            return expected
+
+    class _ServiceStub:
+        def playlist_info(self, identifier):
+            assert identifier == "PL-1"
+            return _PlaylistInfoStub()
+
+    provider.service = _ServiceStub()
+
+    assert provider.toplist_get("PL-1") is expected


### PR DESCRIPTION
## Summary
- add toplist_list/toplist_get with chart playlist extraction
- return raw charts payload from service without auth hack
- add toplist and charts unit tests

## Testing
- [x] uv run pytest
