### PR TITLE
feat: support image media conversion for cover proxy

### DIFF
--- a/fuo_ytmusic/provider.py
+++ b/fuo_ytmusic/provider.py
@@ -20,7 +20,7 @@ from feeluown.library import (
     VideoModel,
 )
 from feeluown.library.model_protocol import BriefSongProtocol
-from feeluown.media import Media, Quality, VideoAudioManifest
+from feeluown.media import Media, MediaType, Quality, VideoAudioManifest
 from feeluown.utils.dispatch import Signal
 from yt_dlp import DownloadError, YoutubeDL
 
@@ -76,6 +76,11 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
 
     def setup_language(self, language: str):
         self.service.setup_language(language)
+
+    def img_url_to_media(self, pic_url: str) -> Media:
+        if self._http_proxy:
+            return Media(pic_url, MediaType.image, http_proxy=self._http_proxy)
+        return Media(pic_url, MediaType.image)
 
     # noinspection PyPep8Naming
     class meta:

--- a/tests/test_provider_media.py
+++ b/tests/test_provider_media.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 from feeluown.excs import ProviderIOError
-from feeluown.media import Quality
+from feeluown.media import MediaType, Quality
 from yt_dlp import DownloadError
 
 from fuo_ytmusic import provider as provider_module
@@ -105,3 +105,35 @@ def test_song_get_media_raises_user_actionable_error(monkeypatch):
         provider.song_get_media(
             SimpleNamespace(identifier="video-id"), Quality.Audio.sq
         )
+
+
+def test_img_url_to_media_passes_http_proxy():
+    provider = YtmusicProvider()
+    provider.setup_http_proxy("http://127.0.0.1:7890")
+
+    media = provider.img_url_to_media("https://img.example.com/cover.jpg")
+
+    assert media.type_ == MediaType.image
+    assert media.url == "https://img.example.com/cover.jpg"
+    assert media.http_proxy == "http://127.0.0.1:7890"
+
+
+def test_img_url_to_media_omits_proxy_when_unset(monkeypatch):
+    provider = YtmusicProvider()
+    captured = {}
+
+    def _media_factory(url, type_, **kwargs):
+        captured["url"] = url
+        captured["type_"] = type_
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(
+            url=url, type_=type_, http_proxy=kwargs.get("http_proxy", "")
+        )
+
+    monkeypatch.setattr(provider_module, "Media", _media_factory)
+
+    media = provider.img_url_to_media("https://img.example.com/cover.jpg")
+
+    assert media.type_ == MediaType.image
+    assert media.url == "https://img.example.com/cover.jpg"
+    assert "http_proxy" not in captured["kwargs"]


### PR DESCRIPTION
## Summary
- implement `img_url_to_media` in ytmusic provider
- convert cover urls to `MediaType.image` consistently
- only pass `http_proxy` when provider proxy is explicitly configured
- add tests for proxy and non-proxy branches

## Testing
- [x] `uv run ruff check fuo_ytmusic/provider.py tests/test_provider_media.py`
- [x] `uv run pytest tests/test_provider_media.py`
