### PR TITLE
feat: translate login and account switch ui text

### DIFF
--- a/fuo_ytmusic/provider_ui.py
+++ b/fuo_ytmusic/provider_ui.py
@@ -13,9 +13,9 @@ from fuo_ytmusic.provider import provider
 from fuo_ytmusic.qt_compat import (
     Dialog,
     QFormLayout,
+    QInputDialog,
     QLabel,
     QLineEdit,
-    QInputDialog,
     QPushButton,
     QVBoxLayout,
     TextSelectableByMouse,
@@ -37,7 +37,7 @@ class ProviderUI(AbstractProviderUi):
         return (Path(__file__).parent / "assets" / "icon.svg").as_posix()
 
     def context_menu_add_items(self, menu):
-        action = menu.addAction("切换账号")
+        action = menu.addAction("Switch account")
         action.triggered.connect(lambda: aio.run_afn_ref(self.switch_profile_dialog))
 
     def login_or_go_home(self):
@@ -59,15 +59,15 @@ class ProviderUI(AbstractProviderUi):
 
     async def switch_profile_dialog(self):
         if not provider.has_current_user():
-            self._app.show_msg("请先登录后再切换账号")
+            self._app.show_msg("Please log in before switching accounts.")
             return
         try:
             profiles = await aio.run_fn(provider.list_profiles)
         except Exception as e:
-            self._app.show_msg(f"获取账号列表失败：{e}")
+            self._app.show_msg(f"Failed to fetch account list: {e}")
             return
         if not profiles:
-            self._app.show_msg("未获取到可用账号")
+            self._app.show_msg("No available accounts found.")
             return
 
         items = []
@@ -81,8 +81,8 @@ class ProviderUI(AbstractProviderUi):
 
         selected, ok = QInputDialog.getItem(
             self._app,
-            "切换账号",
-            "选择账号",
+            "Switch account",
+            "Select an account",
             items,
             0,
             False,
@@ -95,9 +95,9 @@ class ProviderUI(AbstractProviderUi):
         try:
             await aio.run_fn(provider.switch_profile, profile.get("accountName"))
         except Exception as e:
-            self._app.show_msg(f"切换账号失败：{e}")
+            self._app.show_msg(f"Failed to switch account: {e}")
             return
-        self._app.show_msg(f"已切换到：{profile.get('accountName')}")
+        self._app.show_msg(f"Switched to: {profile.get('accountName')}")
         # Notify UI to refresh current user data/playlists.
         self.login_event.emit(self, 2)
 
@@ -108,20 +108,20 @@ class LoginDialog(LoginDialog_):
 
         self._provider = provider
 
-        self._login_btn = QPushButton("登录")
+        self._login_btn = QPushButton("Login")
         self.__hint_label = QLabel(
-            "欢迎来到 Youtube Music 登录界面 :)\n\n"
-            "登录 Youtube Music 虽然繁琐，但一劳‘永逸’（因为认证信息的过期时间很长）。"
-            "当然，不登录也可以使用 Youtube Music 的大部分功能，比如搜索、播放等。"
-            "登录请按照下述指南操作：\n\n"
-            "在浏览器中登录 Youtube Music，打开“开发者工具”，"
-            "点击‘媒体库’按钮（这样会触发一个 POST 请求，这个请求通常会携带必要的认证信息），"
-            "拷贝这个 HTTP 请求的 Authorization 和 Cookie 字段值并填入到表格中，点击登录按钮。"
+            "Welcome to the YouTube Music sign-in dialog.\n\n"
+            "1) Sign in on music.youtube.com in your browser.\n"
+            "2) Open DevTools and trigger a request from Library.\n"
+            "3) Copy Authorization and Cookie from that HTTP request.\n"
+            "4) Paste them into the fields below, then click Login."
         )
         self.__progress_label = QLabel()
         self.__input_auth_header = QLineEdit()
         self.__input_cookies = QLineEdit()
         self.__hint_label.setTextInteractionFlags(TextSelectableByMouse)
+        # Allow users to copy both onboarding hints and runtime status messages.
+        self.__progress_label.setTextInteractionFlags(TextSelectableByMouse)
         self.__hint_label.setWordWrap(True)
         self.__progress_label.setWordWrap(True)
         self.setup_ui()
@@ -137,9 +137,9 @@ class LoginDialog(LoginDialog_):
         )
 
         self.__input_auth_header.setPlaceholderText(
-            "类似：SAPISIDHASH 1765595295_abcd_u SAPISID1PHASH ..."
+            "Example: SAPISIDHASH 1765595295_abcd_u SAPISID1PHASH ..."
         )
-        self.__input_cookies.setPlaceholderText("请复制完整的值")
+        self.__input_cookies.setPlaceholderText("Paste the full cookie value")
         form_layout.addRow("Authorization:", self.__input_auth_header)
         form_layout.addRow("Cookie:", self.__input_cookies)
         self._layout = QVBoxLayout(self)
@@ -157,30 +157,36 @@ class LoginDialog(LoginDialog_):
         auth = self.__input_auth_header.text()
         cookie = self.__input_cookies.text()
         if not (auth and cookie):
-            self.show_progress("请输入 Authorization 和 Cookie", color="red")
+            self.show_progress("Please input Authorization and Cookie.", color="red")
             return
         self.generate_header_file(auth, cookie)
-        self.show_progress("尝试登录...", color="green")
+        self.show_progress("Trying to sign in...", color="green")
         await self.try_login()
 
     async def try_auto_login(self):
         if HEADER_FILE.exists():
-            self.show_progress("发现已存在的认证信息，尝试登录...", color="blue")
+            self.show_progress(
+                "Found existing credentials, trying to sign in...",
+                color="blue",
+            )
             await self.try_login()
         else:
-            self.show_progress("等待用户填充认证信息...", color="blue")
+            self.show_progress("Waiting for credentials...", color="blue")
 
     async def try_login(self):
         try:
             user = await aio.run_fn(self._provider.try_get_user_with_headerfile)
         except Exception as e:
-            self.show_progress(f"登录失败：{e}", color="red")
+            self.show_progress(f"Sign-in failed: {e}", color="red")
             return
 
         if user is None:
-            self.show_progress("登录失败，可能是认证信息无效。", color="red")
+            self.show_progress(
+                "Sign-in failed: credentials may be invalid.",
+                color="red",
+            )
             return
-        self.show_progress(f"登录成功，用户：{user.name}", color="green")
+        self.show_progress(f"Signed in as: {user.name}", color="green")
         self._provider.auth(user)
         self.login_succeed.emit()
         self.hide()


### PR DESCRIPTION
## Summary
- translate login dialog and account-switch flow user-facing text to English
- keep login guidance selectable/copiable and use clear step-by-step onboarding text
- keep placeholders in English for Authorization/Cookie input fields

## Testing
- [x] `uv run ruff check fuo_ytmusic/provider_ui.py`
