### PR TITLE
fix: improve ytmusic artist pic_url resolution

### DIFF
--- a/fuo_ytmusic/models.py
+++ b/fuo_ytmusic/models.py
@@ -261,7 +261,9 @@ class YtmusicHistorySong(YtmusicLibrarySong):
     played: str  # 上次播放 eg November 2021
 
 
-class YtmusicHomeSong(BaseModel, YtmusicCoverMixin, YtmusicArtistsMixin, YtmusicDurationMixin):
+class YtmusicHomeSong(
+    BaseModel, YtmusicCoverMixin, YtmusicArtistsMixin, YtmusicDurationMixin
+):
     """Home feed song item.
 
     Keep this model independent from YtmusicSearchSong:
@@ -430,7 +432,7 @@ class ArtistInfo(BaseModel):
             identifier=identifier,
             source=self.source,
             name=self.name,
-            pic_url=(self.thumbnails[0].url if self.thumbnails else ""),
+            pic_url=(self.thumbnails[-1].url if self.thumbnails else ""),
             aliases=[],
             hot_songs=[
                 song.v2_brief_model()

--- a/tests/test_models_fields.py
+++ b/tests/test_models_fields.py
@@ -54,6 +54,13 @@ def test_artist_info_v2_model_sets_hot_songs():
     assert model.mv_count == -1
 
 
+def test_artist_info_v2_model_prefers_highest_resolution_thumbnail():
+    data = _load_fixture("model_fields_get_artist.json")
+    model = ArtistInfo(**data).v2_model("fixture-artist")
+
+    assert model.pic_url == data["thumbnails"][-1]["url"]
+
+
 def test_song_info_supports_audio_quality_and_media_mapping():
     data = _load_fixture("model_fields_get_song.json")
     song = SongInfo(**data)


### PR DESCRIPTION
## Summary
- prefer the highest-resolution thumbnail for `ArtistInfo.v2_model` `pic_url` mapping
- add a regression test to ensure artist `pic_url` uses the last thumbnail entry from fixture data

## Testing
- `uv run pytest -q tests/test_models_fields.py -k artist_info_v2_model`
- `uv run ruff check fuo_ytmusic/models.py tests/test_models_fields.py`
- `uv run ruff format --check fuo_ytmusic/models.py tests/test_models_fields.py`
