### PR TITLE
Add i18n support for provider name localization

### DIFF
--- a/fuo_ytmusic/i18n/__init__.py
+++ b/fuo_ytmusic/i18n/__init__.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from fluent.runtime import FluentLocalization, FluentResourceLoader
+from feeluown.i18n import _DEFAULT_LOCALE
+
+_DIR = Path(__file__).parent
+_l10n = None
+
+def t(msg_id: str, **kwargs) -> str:
+    global _l10n
+    if _l10n is None:
+        loader = FluentResourceLoader(roots=[str(_DIR / "{locale}")])
+        _l10n = FluentLocalization(
+            locales=[_DEFAULT_LOCALE, "zh-CN", "en-US", "ja-JP"],
+            resource_ids=["provider.ftl"],
+            resource_loader=loader,
+        )
+    return _l10n.format_value(msg_id, kwargs)

--- a/fuo_ytmusic/i18n/en-US/provider.ftl
+++ b/fuo_ytmusic/i18n/en-US/provider.ftl
@@ -1,0 +1,3 @@
+### Localization for YouTube Music
+
+provider-name = YouTube Music

--- a/fuo_ytmusic/i18n/ja-JP/provider.ftl
+++ b/fuo_ytmusic/i18n/ja-JP/provider.ftl
@@ -1,0 +1,3 @@
+### Localization for YouTube Music
+
+provider-name = YouTubeミュージック

--- a/fuo_ytmusic/i18n/zh-CN/provider.ftl
+++ b/fuo_ytmusic/i18n/zh-CN/provider.ftl
@@ -1,0 +1,3 @@
+### Localization for YouTube Music
+
+provider-name = YouTube音乐

--- a/fuo_ytmusic/provider.py
+++ b/fuo_ytmusic/provider.py
@@ -37,6 +37,7 @@ from fuo_ytmusic.models import (
     YtmusicWatchPlaylistSong,
 )
 from fuo_ytmusic.service import YtmusicPrivacyStatus, YtmusicService, YtmusicType
+from .i18n import t
 
 logger = logging.getLogger(__name__)
 
@@ -141,7 +142,7 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
 
     @property
     def name(self):
-        return self.meta.name
+        return t('provider-name')
 
     def auto_login(self):
         if HEADER_FILE.exists():


### PR DESCRIPTION
### 本次 PR 为YouTube Music插件添加了国际化支持，将原有的硬编码名称替换为可翻译的字符串。

### 主要修改：

- 新增 i18n 模块：引入 fluent 库以支持多语言加载与解析。
- 添加翻译资源：新增 `zh-CN、en-US、ja-JP` 三种语言的 `provider.ftl` 文件，定义 `provider-name`。
- 更新代码逻辑：修改 `provider.py`，将 name 属性的返回值从`class meta`里硬编码的 `name = "YouTube Music"` 改为调用 `t('provider-name')` 实现动态翻译。