### PR TITLE
Add YTMusic song lyrics support

### DIFF
--- a/fuo_ytmusic/lyrics.py
+++ b/fuo_ytmusic/lyrics.py
@@ -1,0 +1,64 @@
+from typing import Optional
+
+WATCH_NEXT_RENDERER_PATH = (
+    "contents",
+    "singleColumnMusicWatchNextResultsRenderer",
+    "tabbedRenderer",
+    "watchNextTabbedResultsRenderer",
+)
+
+
+def build_watch_playlist_body(video_id: str) -> dict:
+    return {
+        "enablePersistentPlaylistPanel": True,
+        "isAudioOnly": True,
+        "tunerSettingValue": "AUTOMIX_SETTING_NORMAL",
+        "videoId": video_id,
+        "playlistId": f"RDAMVM{video_id}",
+        "watchEndpointMusicSupportedConfigs": {
+            "watchEndpointMusicConfig": {
+                "hasPersistentPlaylistPanel": True,
+                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV",
+            }
+        },
+    }
+
+
+def extract_lyrics_browse_id(watch_response) -> Optional[str]:
+    tabs = watch_response
+    for key in WATCH_NEXT_RENDERER_PATH:
+        tabs = tabs[key]
+    tabs = tabs["tabs"]
+
+    try:
+        browse_id = tabs[1]["tabRenderer"]["endpoint"]["browseEndpoint"]["browseId"]
+    except (IndexError, KeyError, TypeError):
+        return None
+    if not isinstance(browse_id, str):
+        raise TypeError(f"unexpected lyrics browse id type: {type(browse_id)}")
+    return browse_id
+
+
+def timestamped_lyrics_to_lrc(lyrics_payload) -> Optional[str]:
+    lyrics = lyrics_payload["lyrics"]
+    if not isinstance(lyrics, list):
+        return None
+
+    lines = [format_lyric_line(line) for line in lyrics]
+    if not lines:
+        return None
+    return "\n".join(lines)
+
+
+def format_lyric_line(line) -> str:
+    return f"{format_lrc_timestamp(line.start_time)}{line.text}"
+
+
+def format_lrc_timestamp(milliseconds: int) -> str:
+    if not isinstance(milliseconds, int):
+        raise TypeError(f"unexpected lyric start_time type: {type(milliseconds)}")
+    total_ms = max(0, milliseconds)
+    minutes = total_ms // 60000
+    seconds = (total_ms % 60000) // 1000
+    centiseconds = (total_ms % 1000) // 10
+    return f"[{minutes:02d}:{seconds:02d}.{centiseconds:02d}]"

--- a/fuo_ytmusic/provider.py
+++ b/fuo_ytmusic/provider.py
@@ -10,6 +10,7 @@ from feeluown.library import (
     BriefVideoModel,
     Collection,
     CollectionType,
+    LyricModel,
     ModelNotFound,
     PlaylistModel,
     ProviderV2,
@@ -118,7 +119,9 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
             return ""
         if not self._should_use_ytdlp_cookiefile():
             return ""
-        headerfile_path = getattr(self.service.api, "headerfile_path", None) or HEADER_FILE
+        headerfile_path = (
+            getattr(self.service.api, "headerfile_path", None) or HEADER_FILE
+        )
         cookiefile_path = YtdlpCookiefileManager(headerfile_path).cookiefile_path
         return "" if cookiefile_path is None else str(cookiefile_path)
 
@@ -472,12 +475,28 @@ class YtmusicProvider(AbstractProvider, ProviderV2):
         # hack(cosven): we use get_watch_playlist to try to get song detail.
         # It works for song like '如愿-王菲'.
         result = self.service.api.get_watch_playlist(identifier)
-        songs = [YtmusicWatchPlaylistSong(**track).v2_model() for track in result["tracks"]]
+        songs = [
+            YtmusicWatchPlaylistSong(**track).v2_model() for track in result["tracks"]
+        ]
         for song in songs:
             if song.identifier == identifier:
                 return song
         # I think this branch should not be reached (in most cases).
         return ModelNotFound(f"song:{identifier} not found")
+
+    def song_get_lyric(self, song: BriefSongProtocol) -> Optional[LyricModel]:
+        try:
+            content = self.service.song_lyrics(song.identifier)
+        except Exception as e:
+            logger.warning("fetch ytmusic lyrics failed for %s: %s", song.identifier, e)
+            raise ProviderIOError(f"get song lyric failed: {e}", provider=self)
+        if not content:
+            return None
+        return LyricModel(
+            identifier=song.identifier,
+            source=self.meta.identifier,
+            content=content,
+        )
 
     def song_list_similar(self, song):
         result = self.service.api.get_watch_playlist(song.identifier)

--- a/fuo_ytmusic/service.py
+++ b/fuo_ytmusic/service.py
@@ -14,6 +14,7 @@ from cachetools.func import ttl_cache
 from feeluown.library import SearchType
 from requests import Response
 from ytmusicapi import YTMusic as YTMusicBase
+from ytmusicapi.exceptions import YTMusicServerError
 from ytmusicapi.ytmusic import OAuthCredentials
 
 from fuo_ytmusic.headerfile import (
@@ -47,6 +48,122 @@ CACHE_SIZE = 1
 GLOBAL_LIMIT = 20
 
 logger = logging.getLogger(__name__)
+
+
+WATCH_NEXT_RENDERER_PATH = (
+    "contents",
+    "singleColumnMusicWatchNextResultsRenderer",
+    "tabbedRenderer",
+    "watchNextTabbedResultsRenderer",
+)
+
+
+def _nested_get(data, path):
+    current = data
+    for key in path:
+        if isinstance(key, int):
+            if not isinstance(current, list) or len(current) <= key:
+                return None
+            current = current[key]
+            continue
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _build_watch_playlist_body(video_id: str) -> dict:
+    return {
+        "enablePersistentPlaylistPanel": True,
+        "isAudioOnly": True,
+        "tunerSettingValue": "AUTOMIX_SETTING_NORMAL",
+        "videoId": video_id,
+        "playlistId": f"RDAMVM{video_id}",
+        "watchEndpointMusicSupportedConfigs": {
+            "watchEndpointMusicConfig": {
+                "hasPersistentPlaylistPanel": True,
+                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV",
+            }
+        },
+    }
+
+
+def _extract_lyrics_browse_id(watch_response) -> Optional[str]:
+    browse_id = _nested_get(
+        watch_response,
+        (
+            *WATCH_NEXT_RENDERER_PATH,
+            "tabs",
+            1,
+            "tabRenderer",
+            "endpoint",
+            "browseEndpoint",
+            "browseId",
+        ),
+    )
+    return browse_id if isinstance(browse_id, str) else None
+
+
+def _format_lrc_timestamp(milliseconds) -> Optional[str]:
+    try:
+        total_ms = max(0, int(milliseconds))
+    except (TypeError, ValueError):
+        return None
+    minutes = total_ms // 60000
+    seconds = (total_ms % 60000) // 1000
+    centiseconds = (total_ms % 1000) // 10
+    return f"[{minutes:02d}:{seconds:02d}.{centiseconds:02d}]"
+
+
+def _extract_timed_line_text(line) -> Optional[str]:
+    if isinstance(line, dict):
+        text = line.get("text", line.get("lyricLine"))
+    else:
+        text = getattr(line, "text", None)
+    return None if text is None else str(text)
+
+
+def _extract_timed_line_start_time(line):
+    if isinstance(line, dict):
+        if "start_time" in line:
+            return line.get("start_time")
+        if "startTime" in line:
+            return line.get("startTime")
+        cue_range = line.get("cueRange")
+        if isinstance(cue_range, dict):
+            return cue_range.get("startTimeMilliseconds")
+        return None
+    return getattr(line, "start_time", None)
+
+
+def _format_timed_lyrics(lyrics_lines) -> Optional[str]:
+    lines = []
+    for line in lyrics_lines:
+        text = _extract_timed_line_text(line)
+        timestamp = _format_lrc_timestamp(_extract_timed_line_start_time(line))
+        if text is None or timestamp is None:
+            continue
+        lines.append(f"{timestamp}{text}")
+    if not lines:
+        return None
+    return "\n".join(lines)
+
+
+def _extract_timestamped_lyrics_text(lyrics_payload) -> Optional[str]:
+    if lyrics_payload is None:
+        return None
+    if isinstance(lyrics_payload, dict):
+        lyrics = lyrics_payload.get("lyrics")
+    else:
+        lyrics = getattr(lyrics_payload, "lyrics", None)
+    if isinstance(lyrics, list):
+        return _format_timed_lyrics(lyrics)
+    return None
+
+
+def _is_timestamped_lyrics_unavailable_error(error: YTMusicServerError) -> bool:
+    message = str(error).lower()
+    return "400" in message and "invalid argument" in message
 
 
 class YtmusicType(Enum):
@@ -216,10 +333,13 @@ class YtmusicService(metaclass=Singleton):
     def __init__(self):
         self._session = requests.Session()
         self._api: Optional[YTMusic] = None
+        self._anonymous_lyrics_api: Optional[YTMusic] = None
+        self._timeout: Optional[int] = None
         self._session.hooks["response"].append(self._do_logging)
 
         self._signature_timestamp = 0
         self._api_lock = threading.Lock()
+        self._anonymous_lyrics_api_lock = threading.Lock()
         self._profile_manager = YtmusicProfileManager(self)
         self._language: Optional[str] = None
 
@@ -245,9 +365,12 @@ class YtmusicService(metaclass=Singleton):
         return 0
 
     def reinitialize_by_headerfile(self, headerfile=None):
+        self._api = self._create_api(headerfile, self._session)
+
+    def _create_api(self, headerfile, session: requests.Session) -> YTMusic:
         language = self._language or "zh_CN"
         options = dict(
-            requests_session=self._session,
+            requests_session=session,
             language=language,
             oauth_credentials=OAuthCredentials(
                 # In the new version of ytmusicapi, client_id and client_secret
@@ -259,7 +382,7 @@ class YtmusicService(metaclass=Singleton):
                     ".apps.googleusercontent.com"
                 ),
                 client_secret="SboVhoG9s0rNafixCSGGKXAT",
-                session=self._session,
+                session=session,
             ),
         )
         # Due to https://github.com/sigma67/ytmusicapi/issues/676,
@@ -267,27 +390,51 @@ class YtmusicService(metaclass=Singleton):
         # So initialize without auth file when 400 is returned.
         if headerfile is not None and headerfile.exists():
             logger.info("Initializing ytmusic api with headerfile.")
-            self._api = YTMusic(str(headerfile), **options)
-            self._api.set_headerfile_path(headerfile)
+            api = YTMusic(str(headerfile), **options)
+            api.set_headerfile_path(headerfile)
         else:
             logger.info("Initializing ytmusic api with no headerfile.")
-            self._api = YTMusic(**options)
+            api = YTMusic(**options)
+        return api
+
+    def _get_anonymous_lyrics_api(self) -> YTMusic:
+        if self._anonymous_lyrics_api is None:
+            with self._anonymous_lyrics_api_lock:
+                if self._anonymous_lyrics_api is None:
+                    session = requests.Session()
+                    session.hooks["response"].append(self._do_logging)
+                    session.proxies = dict(self._session.proxies)
+                    if self._timeout is not None:
+                        session.request = partial(
+                            session.request,
+                            timeout=self._timeout,
+                        )
+                    self._anonymous_lyrics_api = self._create_api(None, session)
+        return self._anonymous_lyrics_api
+
+    def _clear_anonymous_lyrics_api(self):
+        with self._anonymous_lyrics_api_lock:
+            self._anonymous_lyrics_api = None
 
     def setup_language(self, language: str):
         self._language = language
+        self._clear_anonymous_lyrics_api()
 
     def setup_http_proxy(self, http_proxy):
         self._session.proxies = {
             "http": http_proxy,
             "https": http_proxy,
         }
+        self._clear_anonymous_lyrics_api()
 
     def setup_timeout(self, timeout):
+        self._timeout = timeout
         if isinstance(self._session.request, partial):
             request = self._session.request.func
         else:
             request = self._session.request
         self._session.request = partial(request, timeout=timeout)
+        self._clear_anonymous_lyrics_api()
 
     def search(
         self,
@@ -364,6 +511,36 @@ class YtmusicService(metaclass=Singleton):
 
     def song_info(self, video_id: str) -> SongInfo:
         return SongInfo(**self.api.get_song(video_id, self.get_signature_timestamp()))
+
+    def _song_lyrics_browse_id(self, video_id: str, api=None) -> Optional[str]:
+        api = api or self.api
+        send_api_request = getattr(api, "send_api_request", None)
+        if callable(send_api_request):
+            response = send_api_request("next", _build_watch_playlist_body(video_id))
+            return _extract_lyrics_browse_id(response)
+
+        watch_playlist = api.get_watch_playlist(video_id)
+        if not isinstance(watch_playlist, dict):
+            return None
+        lyrics_browse_id = watch_playlist.get("lyrics")
+        return lyrics_browse_id if isinstance(lyrics_browse_id, str) else None
+
+    def song_lyrics(self, video_id: str) -> Optional[str]:
+        lyrics_api = self._get_anonymous_lyrics_api()
+        lyrics_browse_id = self._song_lyrics_browse_id(video_id, api=lyrics_api)
+        if not lyrics_browse_id:
+            return None
+        try:
+            lyrics_payload = lyrics_api.get_lyrics(lyrics_browse_id, timestamps=True)
+        except YTMusicServerError as e:
+            if _is_timestamped_lyrics_unavailable_error(e):
+                return None
+            raise
+        except TypeError as e:
+            if "timestamps" not in str(e):
+                raise
+            return None
+        return _extract_timestamped_lyrics_text(lyrics_payload)
 
     @ttl_cache(maxsize=CACHE_SIZE, ttl=CACHE_TTL)
     def categories(self) -> List[Categories]:

--- a/fuo_ytmusic/service.py
+++ b/fuo_ytmusic/service.py
@@ -289,6 +289,9 @@ class YtmusicService(metaclass=Singleton):
         if self._anonymous_lyrics_api is None:
             with self._anonymous_lyrics_api_lock:
                 if self._anonymous_lyrics_api is None:
+                    # Headerfile-authenticated clients can get HTTP 400 when
+                    # requesting timestamped lyrics, while anonymous requests
+                    # for the same lyrics browse id succeed.
                     session = requests.Session()
                     session.hooks["response"].append(self._do_logging)
                     session.proxies = dict(self._session.proxies)

--- a/fuo_ytmusic/service.py
+++ b/fuo_ytmusic/service.py
@@ -14,13 +14,17 @@ from cachetools.func import ttl_cache
 from feeluown.library import SearchType
 from requests import Response
 from ytmusicapi import YTMusic as YTMusicBase
-from ytmusicapi.exceptions import YTMusicServerError
 from ytmusicapi.ytmusic import OAuthCredentials
 
 from fuo_ytmusic.headerfile import (
     update_headerfile_cookie,
 )
 from fuo_ytmusic.helpers import Singleton
+from fuo_ytmusic.lyrics import (
+    build_watch_playlist_body,
+    extract_lyrics_browse_id,
+    timestamped_lyrics_to_lrc,
+)
 from fuo_ytmusic.models import (
     AlbumInfo,
     ArtistInfo,
@@ -48,122 +52,6 @@ CACHE_SIZE = 1
 GLOBAL_LIMIT = 20
 
 logger = logging.getLogger(__name__)
-
-
-WATCH_NEXT_RENDERER_PATH = (
-    "contents",
-    "singleColumnMusicWatchNextResultsRenderer",
-    "tabbedRenderer",
-    "watchNextTabbedResultsRenderer",
-)
-
-
-def _nested_get(data, path):
-    current = data
-    for key in path:
-        if isinstance(key, int):
-            if not isinstance(current, list) or len(current) <= key:
-                return None
-            current = current[key]
-            continue
-        if not isinstance(current, dict):
-            return None
-        current = current.get(key)
-    return current
-
-
-def _build_watch_playlist_body(video_id: str) -> dict:
-    return {
-        "enablePersistentPlaylistPanel": True,
-        "isAudioOnly": True,
-        "tunerSettingValue": "AUTOMIX_SETTING_NORMAL",
-        "videoId": video_id,
-        "playlistId": f"RDAMVM{video_id}",
-        "watchEndpointMusicSupportedConfigs": {
-            "watchEndpointMusicConfig": {
-                "hasPersistentPlaylistPanel": True,
-                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV",
-            }
-        },
-    }
-
-
-def _extract_lyrics_browse_id(watch_response) -> Optional[str]:
-    browse_id = _nested_get(
-        watch_response,
-        (
-            *WATCH_NEXT_RENDERER_PATH,
-            "tabs",
-            1,
-            "tabRenderer",
-            "endpoint",
-            "browseEndpoint",
-            "browseId",
-        ),
-    )
-    return browse_id if isinstance(browse_id, str) else None
-
-
-def _format_lrc_timestamp(milliseconds) -> Optional[str]:
-    try:
-        total_ms = max(0, int(milliseconds))
-    except (TypeError, ValueError):
-        return None
-    minutes = total_ms // 60000
-    seconds = (total_ms % 60000) // 1000
-    centiseconds = (total_ms % 1000) // 10
-    return f"[{minutes:02d}:{seconds:02d}.{centiseconds:02d}]"
-
-
-def _extract_timed_line_text(line) -> Optional[str]:
-    if isinstance(line, dict):
-        text = line.get("text", line.get("lyricLine"))
-    else:
-        text = getattr(line, "text", None)
-    return None if text is None else str(text)
-
-
-def _extract_timed_line_start_time(line):
-    if isinstance(line, dict):
-        if "start_time" in line:
-            return line.get("start_time")
-        if "startTime" in line:
-            return line.get("startTime")
-        cue_range = line.get("cueRange")
-        if isinstance(cue_range, dict):
-            return cue_range.get("startTimeMilliseconds")
-        return None
-    return getattr(line, "start_time", None)
-
-
-def _format_timed_lyrics(lyrics_lines) -> Optional[str]:
-    lines = []
-    for line in lyrics_lines:
-        text = _extract_timed_line_text(line)
-        timestamp = _format_lrc_timestamp(_extract_timed_line_start_time(line))
-        if text is None or timestamp is None:
-            continue
-        lines.append(f"{timestamp}{text}")
-    if not lines:
-        return None
-    return "\n".join(lines)
-
-
-def _extract_timestamped_lyrics_text(lyrics_payload) -> Optional[str]:
-    if lyrics_payload is None:
-        return None
-    if isinstance(lyrics_payload, dict):
-        lyrics = lyrics_payload.get("lyrics")
-    else:
-        lyrics = getattr(lyrics_payload, "lyrics", None)
-    if isinstance(lyrics, list):
-        return _format_timed_lyrics(lyrics)
-    return None
-
-
-def _is_timestamped_lyrics_unavailable_error(error: YTMusicServerError) -> bool:
-    message = str(error).lower()
-    return "400" in message and "invalid argument" in message
 
 
 class YtmusicType(Enum):
@@ -513,34 +401,18 @@ class YtmusicService(metaclass=Singleton):
         return SongInfo(**self.api.get_song(video_id, self.get_signature_timestamp()))
 
     def _song_lyrics_browse_id(self, video_id: str, api=None) -> Optional[str]:
-        api = api or self.api
-        send_api_request = getattr(api, "send_api_request", None)
-        if callable(send_api_request):
-            response = send_api_request("next", _build_watch_playlist_body(video_id))
-            return _extract_lyrics_browse_id(response)
-
-        watch_playlist = api.get_watch_playlist(video_id)
-        if not isinstance(watch_playlist, dict):
-            return None
-        lyrics_browse_id = watch_playlist.get("lyrics")
-        return lyrics_browse_id if isinstance(lyrics_browse_id, str) else None
+        if api is None:
+            api = self.api
+        response = api.send_api_request("next", build_watch_playlist_body(video_id))
+        return extract_lyrics_browse_id(response)
 
     def song_lyrics(self, video_id: str) -> Optional[str]:
         lyrics_api = self._get_anonymous_lyrics_api()
         lyrics_browse_id = self._song_lyrics_browse_id(video_id, api=lyrics_api)
-        if not lyrics_browse_id:
+        if lyrics_browse_id is None:
             return None
-        try:
-            lyrics_payload = lyrics_api.get_lyrics(lyrics_browse_id, timestamps=True)
-        except YTMusicServerError as e:
-            if _is_timestamped_lyrics_unavailable_error(e):
-                return None
-            raise
-        except TypeError as e:
-            if "timestamps" not in str(e):
-                raise
-            return None
-        return _extract_timestamped_lyrics_text(lyrics_payload)
+        lyrics_payload = lyrics_api.get_lyrics(lyrics_browse_id, timestamps=True)
+        return timestamped_lyrics_to_lrc(lyrics_payload)
 
     @ttl_cache(maxsize=CACHE_SIZE, ttl=CACHE_TTL)
     def categories(self) -> List[Categories]:

--- a/manual_tests/lyrics_e2e_test.py
+++ b/manual_tests/lyrics_e2e_test.py
@@ -1,0 +1,103 @@
+"""Manual end-to-end test for YTMusic timestamped lyrics.
+
+Run with:
+  uv run pytest manual_tests/lyrics_e2e_test.py -s --run-manual-tests
+
+Optional environment variables:
+  YTMUSIC_MANUAL_PROXY          HTTP proxy url, e.g. http://127.0.0.1:7890
+  YTMUSIC_MANUAL_TIMEOUT        socket timeout in seconds (default: 8)
+  YTMUSIC_MANUAL_LYRIC_SONG_IDS comma-separated song ids (default: tn7rzN8ABuo)
+  YTMUSIC_MANUAL_USE_HEADERFILE set to 1 to authenticate with ytmusic_header.json
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import socket
+from types import SimpleNamespace
+
+import pytest
+from feeluown.player.lyric import parse_lyric_text
+
+from fuo_ytmusic.consts import HEADER_FILE
+from fuo_ytmusic.provider import provider
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name, "").strip()
+    if not value:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _env_bool(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_song_ids() -> list[str]:
+    value = os.getenv("YTMUSIC_MANUAL_LYRIC_SONG_IDS", "").strip()
+    if not value:
+        return ["tn7rzN8ABuo"]
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def _env_proxy() -> str:
+    return (
+        os.getenv("YTMUSIC_MANUAL_PROXY", "").strip()
+        or os.getenv("HTTP_PROXY", "").strip()
+        or os.getenv("http_proxy", "").strip()
+    )
+
+
+def _setup_provider(timeout: int, proxy: str):
+    socket.setdefaulttimeout(timeout)
+    if proxy:
+        provider.setup_http_proxy(proxy)
+    provider.setup_http_timeout(timeout)
+
+    if not _env_bool("YTMUSIC_MANUAL_USE_HEADERFILE"):
+        print("running anonymously")
+        return
+
+    if not HEADER_FILE.exists():
+        print(f"headerfile not found, running anonymously: {HEADER_FILE}")
+        return
+
+    user = provider.try_get_user_with_headerfile()
+    if user is None:
+        print("auto login failed, running anonymously")
+        return
+    provider.auth(user)
+
+
+@pytest.mark.manual
+def test_song_get_lyric_end_to_end():
+    timeout = _env_int("YTMUSIC_MANUAL_TIMEOUT", 8)
+    proxy = _env_proxy()
+    song_ids = _env_song_ids()
+
+    _setup_provider(timeout, proxy)
+    print(
+        f"manual lyrics config: timeout={timeout}, proxy={'set' if proxy else 'unset'}"
+    )
+
+    for song_id in song_ids:
+        print(f"\n=== song={song_id} ===")
+        lyric = provider.song_get_lyric(SimpleNamespace(identifier=song_id))
+        if lyric is None:
+            pytest.fail(f"no timestamped lyrics returned for {song_id}")
+
+        parsed = parse_lyric_text(lyric.content)
+        assert parsed, "lyric content should be parseable by FeelUOwn as LRC"
+        print(f"timestamped lines: {len(parsed)}")
+        summaries = []
+        for line in lyric.content.splitlines()[:10]:
+            timestamp = line.split("]", 1)[0] + "]" if "]" in line else ""
+            digest = hashlib.sha1(line.encode()).hexdigest()[:10]
+            summaries.append((timestamp, len(line), digest))
+        print(f"first 10 line summaries: {summaries}")
+        print(f"first 10 parsed timestamps: {list(parsed.keys())[:10]}")

--- a/tests/test_lyrics.py
+++ b/tests/test_lyrics.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+
+import pytest
+
+from fuo_ytmusic.lyrics import (
+    build_watch_playlist_body,
+    extract_lyrics_browse_id,
+    format_lrc_timestamp,
+    timestamped_lyrics_to_lrc,
+)
+
+
+def test_build_watch_playlist_body():
+    body = build_watch_playlist_body("video-id")
+
+    assert body["videoId"] == "video-id"
+    assert body["playlistId"] == "RDAMVMvideo-id"
+    assert body["isAudioOnly"] is True
+
+
+def test_extract_lyrics_browse_id_ignores_related_tab_without_endpoint():
+    watch_response = _watch_response("MPLYt_lyrics", related_has_endpoint=False)
+
+    assert extract_lyrics_browse_id(watch_response) == "MPLYt_lyrics"
+
+
+def test_extract_lyrics_browse_id_returns_none_without_lyrics_endpoint():
+    watch_response = _watch_response(None, related_has_endpoint=False)
+
+    assert extract_lyrics_browse_id(watch_response) is None
+
+
+def test_timestamped_lyrics_to_lrc_formats_ytmusic_lyric_lines():
+    payload = {
+        "lyrics": [
+            SimpleNamespace(text="first line", start_time=9200),
+            SimpleNamespace(text="second line", start_time=10680),
+        ],
+        "hasTimestamps": True,
+    }
+
+    assert (
+        timestamped_lyrics_to_lrc(payload)
+        == "[00:09.20]first line\n[00:10.68]second line"
+    )
+
+
+def test_timestamped_lyrics_to_lrc_returns_none_for_plain_text_payload():
+    assert (
+        timestamped_lyrics_to_lrc({"lyrics": "line 1\nline 2", "hasTimestamps": False})
+        is None
+    )
+
+
+def test_timestamped_lyrics_to_lrc_raises_for_malformed_line():
+    with pytest.raises(AttributeError):
+        timestamped_lyrics_to_lrc({"lyrics": [{"text": "raw line", "start_time": 0}]})
+
+
+def test_format_lrc_timestamp_rejects_non_int_start_time():
+    with pytest.raises(TypeError):
+        format_lrc_timestamp("1000")
+
+
+def _watch_response(lyrics_browse_id, related_has_endpoint=True):
+    lyrics_tab = {"tabRenderer": {"title": "Lyrics"}}
+    if lyrics_browse_id:
+        lyrics_tab["tabRenderer"]["endpoint"] = {
+            "browseEndpoint": {"browseId": lyrics_browse_id}
+        }
+
+    related_tab = {"tabRenderer": {"title": "Related"}}
+    if related_has_endpoint:
+        related_tab["tabRenderer"]["endpoint"] = {
+            "browseEndpoint": {"browseId": "MPLYt_related"}
+        }
+
+    return {
+        "contents": {
+            "singleColumnMusicWatchNextResultsRenderer": {
+                "tabbedRenderer": {
+                    "watchNextTabbedResultsRenderer": {
+                        "tabs": [
+                            {"tabRenderer": {"title": "Queue"}},
+                            lyrics_tab,
+                            related_tab,
+                        ]
+                    }
+                }
+            }
+        }
+    }

--- a/tests/test_provider_song_get.py
+++ b/tests/test_provider_song_get.py
@@ -1,5 +1,8 @@
 from types import SimpleNamespace
 
+import pytest
+from feeluown.excs import ProviderIOError
+
 from fuo_ytmusic.provider import YtmusicProvider
 
 
@@ -93,3 +96,47 @@ def test_song_list_similar_handles_watch_playlist_thumbnail_and_length_fields():
     assert songs[0].identifier == "sim-1"
     assert songs[0].pic_url == "https://example.com/sim-544.jpg"
     assert songs[0].duration > 0
+
+
+def test_song_get_lyric_returns_lyric_model():
+    class _ServiceStub:
+        @staticmethod
+        def song_lyrics(identifier):
+            assert identifier == "video-id"
+            return "line 1\nline 2"
+
+    provider = YtmusicProvider()
+    provider.service = _ServiceStub()
+
+    lyric = provider.song_get_lyric(SimpleNamespace(identifier="video-id"))
+
+    assert lyric.identifier == "video-id"
+    assert lyric.source == provider.identifier
+    assert lyric.content == "line 1\nline 2"
+    assert lyric.trans_content == ""
+
+
+def test_song_get_lyric_returns_none_when_unavailable():
+    class _ServiceStub:
+        @staticmethod
+        def song_lyrics(identifier):
+            assert identifier == "video-id"
+            return None
+
+    provider = YtmusicProvider()
+    provider.service = _ServiceStub()
+
+    assert provider.song_get_lyric(SimpleNamespace(identifier="video-id")) is None
+
+
+def test_song_get_lyric_wraps_service_error():
+    class _ServiceStub:
+        @staticmethod
+        def song_lyrics(_identifier):
+            raise RuntimeError("network failed")
+
+    provider = YtmusicProvider()
+    provider.service = _ServiceStub()
+
+    with pytest.raises(ProviderIOError, match="get song lyric failed"):
+        provider.song_get_lyric(SimpleNamespace(identifier="video-id"))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3,8 +3,8 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
+import pytest
 from feeluown.library import SearchType
-from ytmusicapi.exceptions import YTMusicServerError
 
 from fuo_ytmusic import service
 from fuo_ytmusic.models import YtmusicSearchAlbum, YtmusicSearchSong
@@ -106,23 +106,15 @@ class TestService:
     def test_song_lyrics_returns_none_for_plain_text_payload(self):
         self._set_lyrics_api(
             _LyricsApi(
-                watch_playlist={"lyrics": "MPLYt_lyrics"},
                 lyrics_payload={"lyrics": "line 1\nline 2", "hasTimestamps": False},
             )
         )
 
         assert self.service.song_lyrics("video-id") is None
 
-    def test_song_lyrics_uses_anonymous_api_when_auth_api_rejects_timed_lyrics(self):
-        auth_api = _LyricsApi(
-            watch_playlist={"lyrics": "MPLYt_lyrics"},
-            lyrics_error=YTMusicServerError(
-                "Server returned HTTP 400: Bad Request.\n"
-                "Request contains an invalid argument."
-            ),
-        )
+    def test_song_lyrics_uses_anonymous_api(self):
+        auth_api = _LyricsApi()
         anonymous_api = _LyricsApi(
-            watch_playlist={"lyrics": "MPLYt_lyrics"},
             lyrics_payload={
                 "lyrics": [SimpleNamespace(text="anonymous line", start_time=1000)],
                 "hasTimestamps": True,
@@ -165,20 +157,9 @@ class TestService:
         assert create_count == 1
         assert results == [api] * 8
 
-    def test_song_lyrics_returns_none_for_plain_object_payload(self):
-        self._set_lyrics_api(
-            _LyricsApi(
-                watch_playlist={"lyrics": "MPLYt_lyrics"},
-                lyrics_payload=SimpleNamespace(lyrics="object lyric"),
-            )
-        )
-
-        assert self.service.song_lyrics("video-id") is None
-
     def test_song_lyrics_formats_timestamped_lines_as_lrc(self):
         self._set_lyrics_api(
             _LyricsApi(
-                watch_playlist={"lyrics": "MPLYt_lyrics"},
                 lyrics_payload={
                     "lyrics": [
                         SimpleNamespace(text="first line", start_time=9200),
@@ -194,31 +175,13 @@ class TestService:
             == "[00:09.20]first line\n[00:10.68]second line"
         )
 
-    def test_song_lyrics_formats_raw_timestamped_lines_as_lrc(self):
-        self._set_lyrics_api(
-            _LyricsApi(
-                watch_playlist={"lyrics": "MPLYt_lyrics"},
-                lyrics_payload={
-                    "lyrics": [
-                        {
-                            "lyricLine": "raw line",
-                            "cueRange": {"startTimeMilliseconds": "61500"},
-                        }
-                    ],
-                    "hasTimestamps": True,
-                },
-            )
-        )
-
-        assert self.service.song_lyrics("video-id") == "[01:01.50]raw line"
-
     def test_song_lyrics_returns_none_without_browse_id(self):
-        self._set_lyrics_api(_LyricsApi(watch_playlist={"lyrics": None}))
+        self._set_lyrics_api(_LyricsApi(lyrics_browse_id=None))
 
         assert self.service.song_lyrics("video-id") is None
 
     def test_song_lyrics_uses_raw_next_response_and_ignores_related_tab(self):
-        api = _RawLyricsApi(
+        api = _LyricsApi(
             watch_response=_watch_response("MPLYt_lyrics", related_has_endpoint=False),
             lyrics_payload={
                 "lyrics": [SimpleNamespace(text="raw lyric", start_time=1000)],
@@ -231,7 +194,7 @@ class TestService:
         assert api.timestamps_requested is True
 
     def test_song_lyrics_returns_none_when_raw_lyrics_tab_has_no_endpoint(self):
-        api = _RawLyricsApi(
+        api = _LyricsApi(
             watch_response=_watch_response(None, related_has_endpoint=False),
             lyrics_payload={"lyrics": "should not be requested"},
         )
@@ -240,18 +203,15 @@ class TestService:
         assert self.service.song_lyrics("video-id") is None
         assert api.lyrics_requested is False
 
-    def test_song_lyrics_returns_none_when_timestamped_request_is_invalid(self):
+    def test_song_lyrics_propagates_timestamped_request_error(self):
         self._set_lyrics_api(
             _LyricsApi(
-                watch_playlist={"lyrics": "MPLYt_lyrics"},
-                lyrics_error=YTMusicServerError(
-                    "Server returned HTTP 400: Bad Request.\n"
-                    "Request contains an invalid argument."
-                ),
+                lyrics_error=RuntimeError("invalid timed lyrics request"),
             )
         )
 
-        assert self.service.song_lyrics("video-id") is None
+        with pytest.raises(RuntimeError, match="invalid timed lyrics request"):
+            self.service.song_lyrics("video-id")
 
 
 class _StubApi:
@@ -271,30 +231,22 @@ class _ChartsApi:
 
 
 class _LyricsApi:
-    def __init__(self, watch_playlist, lyrics_payload=None, lyrics_error=None):
-        self.watch_playlist = watch_playlist
+    def __init__(
+        self,
+        lyrics_browse_id="MPLYt_lyrics",
+        lyrics_payload=None,
+        lyrics_error=None,
+        watch_response=None,
+    ):
+        self.watch_response = (
+            _watch_response(lyrics_browse_id)
+            if watch_response is None
+            else watch_response
+        )
         self.lyrics_payload = lyrics_payload
         self.lyrics_error = lyrics_error
         self.lyrics_requested = False
         self.timestamps_requested = None
-
-    def get_watch_playlist(self, video_id):
-        assert video_id == "video-id"
-        return self.watch_playlist
-
-    def get_lyrics(self, browse_id, timestamps=False):
-        assert browse_id == "MPLYt_lyrics"
-        self.lyrics_requested = True
-        self.timestamps_requested = timestamps
-        if self.lyrics_error is not None:
-            raise self.lyrics_error
-        return self.lyrics_payload
-
-
-class _RawLyricsApi(_LyricsApi):
-    def __init__(self, watch_response, lyrics_payload=None):
-        super().__init__(watch_playlist=None, lyrics_payload=lyrics_payload)
-        self.watch_response = watch_response
 
     def send_api_request(self, endpoint, body):
         assert endpoint == "next"
@@ -303,8 +255,13 @@ class _RawLyricsApi(_LyricsApi):
         assert body["isAudioOnly"] is True
         return self.watch_response
 
-    def get_watch_playlist(self, _video_id):
-        raise AssertionError("song_lyrics should use raw next response")
+    def get_lyrics(self, browse_id, timestamps=False):
+        assert browse_id == "MPLYt_lyrics"
+        self.lyrics_requested = True
+        self.timestamps_requested = timestamps
+        if self.lyrics_error is not None:
+            raise self.lyrics_error
+        return self.lyrics_payload
 
 
 def _watch_response(lyrics_browse_id, related_has_endpoint=True):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -123,6 +123,8 @@ class TestService:
         self.service._api = auth_api
         self.service._anonymous_lyrics_api = anonymous_api
 
+        # Regression: authenticated/headerfile clients returned HTTP 400 for
+        # timestamped lyrics in manual testing, so lyrics must bypass self._api.
         assert self.service.song_lyrics("video-id") == "[00:01.00]anonymous line"
         assert auth_api.lyrics_requested is False
         assert anonymous_api.lyrics_requested is True

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,6 +1,10 @@
 import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
 
 from feeluown.library import SearchType
+from ytmusicapi.exceptions import YTMusicServerError
 
 from fuo_ytmusic import service
 from fuo_ytmusic.models import YtmusicSearchAlbum, YtmusicSearchSong
@@ -11,9 +15,20 @@ class TestService:
         service.logger.addHandler(logging.StreamHandler())
         service.logger.setLevel(logging.DEBUG)
         self.service = service.YtmusicService()
+        self.service._api = None
+        self.service._anonymous_lyrics_api = None
+        self.service._anonymous_lyrics_api_lock = threading.Lock()
+        self.service._create_api = service.YtmusicService._create_api.__get__(
+            self.service,
+            service.YtmusicService,
+        )
 
     def teardown_method(self):
         del self.service
+
+    def _set_lyrics_api(self, api):
+        self.service._api = api
+        self.service._anonymous_lyrics_api = api
 
     def test_ytmusic_type(self):
         assert service.YtmusicType.parse(SearchType.so) == service.YtmusicType.so
@@ -88,6 +103,156 @@ class TestService:
 
         assert self.service.get_charts("ZZ") == {}
 
+    def test_song_lyrics_returns_none_for_plain_text_payload(self):
+        self._set_lyrics_api(
+            _LyricsApi(
+                watch_playlist={"lyrics": "MPLYt_lyrics"},
+                lyrics_payload={"lyrics": "line 1\nline 2", "hasTimestamps": False},
+            )
+        )
+
+        assert self.service.song_lyrics("video-id") is None
+
+    def test_song_lyrics_uses_anonymous_api_when_auth_api_rejects_timed_lyrics(self):
+        auth_api = _LyricsApi(
+            watch_playlist={"lyrics": "MPLYt_lyrics"},
+            lyrics_error=YTMusicServerError(
+                "Server returned HTTP 400: Bad Request.\n"
+                "Request contains an invalid argument."
+            ),
+        )
+        anonymous_api = _LyricsApi(
+            watch_playlist={"lyrics": "MPLYt_lyrics"},
+            lyrics_payload={
+                "lyrics": [SimpleNamespace(text="anonymous line", start_time=1000)],
+                "hasTimestamps": True,
+            },
+        )
+        self.service._api = auth_api
+        self.service._anonymous_lyrics_api = anonymous_api
+
+        assert self.service.song_lyrics("video-id") == "[00:01.00]anonymous line"
+        assert auth_api.lyrics_requested is False
+        assert anonymous_api.lyrics_requested is True
+
+    def test_anonymous_lyrics_api_initializes_once_across_threads(self):
+        api = object()
+        create_count = 0
+        create_count_lock = threading.Lock()
+        create_started = threading.Event()
+        release_create = threading.Event()
+
+        def create_api(headerfile, _session):
+            nonlocal create_count
+            assert headerfile is None
+            with create_count_lock:
+                create_count += 1
+            create_started.set()
+            release_create.wait(timeout=1)
+            return api
+
+        self.service._create_api = create_api
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            futures = [
+                executor.submit(self.service._get_anonymous_lyrics_api)
+                for _ in range(8)
+            ]
+            assert create_started.wait(timeout=1)
+            release_create.set()
+            results = [future.result(timeout=1) for future in futures]
+
+        assert create_count == 1
+        assert results == [api] * 8
+
+    def test_song_lyrics_returns_none_for_plain_object_payload(self):
+        self._set_lyrics_api(
+            _LyricsApi(
+                watch_playlist={"lyrics": "MPLYt_lyrics"},
+                lyrics_payload=SimpleNamespace(lyrics="object lyric"),
+            )
+        )
+
+        assert self.service.song_lyrics("video-id") is None
+
+    def test_song_lyrics_formats_timestamped_lines_as_lrc(self):
+        self._set_lyrics_api(
+            _LyricsApi(
+                watch_playlist={"lyrics": "MPLYt_lyrics"},
+                lyrics_payload={
+                    "lyrics": [
+                        SimpleNamespace(text="first line", start_time=9200),
+                        SimpleNamespace(text="second line", start_time=10680),
+                    ],
+                    "hasTimestamps": True,
+                },
+            )
+        )
+
+        assert (
+            self.service.song_lyrics("video-id")
+            == "[00:09.20]first line\n[00:10.68]second line"
+        )
+
+    def test_song_lyrics_formats_raw_timestamped_lines_as_lrc(self):
+        self._set_lyrics_api(
+            _LyricsApi(
+                watch_playlist={"lyrics": "MPLYt_lyrics"},
+                lyrics_payload={
+                    "lyrics": [
+                        {
+                            "lyricLine": "raw line",
+                            "cueRange": {"startTimeMilliseconds": "61500"},
+                        }
+                    ],
+                    "hasTimestamps": True,
+                },
+            )
+        )
+
+        assert self.service.song_lyrics("video-id") == "[01:01.50]raw line"
+
+    def test_song_lyrics_returns_none_without_browse_id(self):
+        self._set_lyrics_api(_LyricsApi(watch_playlist={"lyrics": None}))
+
+        assert self.service.song_lyrics("video-id") is None
+
+    def test_song_lyrics_uses_raw_next_response_and_ignores_related_tab(self):
+        api = _RawLyricsApi(
+            watch_response=_watch_response("MPLYt_lyrics", related_has_endpoint=False),
+            lyrics_payload={
+                "lyrics": [SimpleNamespace(text="raw lyric", start_time=1000)],
+                "hasTimestamps": True,
+            },
+        )
+        self._set_lyrics_api(api)
+
+        assert self.service.song_lyrics("video-id") == "[00:01.00]raw lyric"
+        assert api.timestamps_requested is True
+
+    def test_song_lyrics_returns_none_when_raw_lyrics_tab_has_no_endpoint(self):
+        api = _RawLyricsApi(
+            watch_response=_watch_response(None, related_has_endpoint=False),
+            lyrics_payload={"lyrics": "should not be requested"},
+        )
+        self._set_lyrics_api(api)
+
+        assert self.service.song_lyrics("video-id") is None
+        assert api.lyrics_requested is False
+
+    def test_song_lyrics_returns_none_when_timestamped_request_is_invalid(self):
+        self._set_lyrics_api(
+            _LyricsApi(
+                watch_playlist={"lyrics": "MPLYt_lyrics"},
+                lyrics_error=YTMusicServerError(
+                    "Server returned HTTP 400: Bad Request.\n"
+                    "Request contains an invalid argument."
+                ),
+            )
+        )
+
+        assert self.service.song_lyrics("video-id") is None
+
 
 class _StubApi:
     def __init__(self, payload):
@@ -103,3 +268,70 @@ class _ChartsApi:
 
     def get_charts(self, *_args, **_kwargs):
         return self.payload
+
+
+class _LyricsApi:
+    def __init__(self, watch_playlist, lyrics_payload=None, lyrics_error=None):
+        self.watch_playlist = watch_playlist
+        self.lyrics_payload = lyrics_payload
+        self.lyrics_error = lyrics_error
+        self.lyrics_requested = False
+        self.timestamps_requested = None
+
+    def get_watch_playlist(self, video_id):
+        assert video_id == "video-id"
+        return self.watch_playlist
+
+    def get_lyrics(self, browse_id, timestamps=False):
+        assert browse_id == "MPLYt_lyrics"
+        self.lyrics_requested = True
+        self.timestamps_requested = timestamps
+        if self.lyrics_error is not None:
+            raise self.lyrics_error
+        return self.lyrics_payload
+
+
+class _RawLyricsApi(_LyricsApi):
+    def __init__(self, watch_response, lyrics_payload=None):
+        super().__init__(watch_playlist=None, lyrics_payload=lyrics_payload)
+        self.watch_response = watch_response
+
+    def send_api_request(self, endpoint, body):
+        assert endpoint == "next"
+        assert body["videoId"] == "video-id"
+        assert body["playlistId"] == "RDAMVMvideo-id"
+        assert body["isAudioOnly"] is True
+        return self.watch_response
+
+    def get_watch_playlist(self, _video_id):
+        raise AssertionError("song_lyrics should use raw next response")
+
+
+def _watch_response(lyrics_browse_id, related_has_endpoint=True):
+    lyrics_tab = {"tabRenderer": {"title": "Lyrics"}}
+    if lyrics_browse_id:
+        lyrics_tab["tabRenderer"]["endpoint"] = {
+            "browseEndpoint": {"browseId": lyrics_browse_id}
+        }
+
+    related_tab = {"tabRenderer": {"title": "Related"}}
+    if related_has_endpoint:
+        related_tab["tabRenderer"]["endpoint"] = {
+            "browseEndpoint": {"browseId": "MPLYt_related"}
+        }
+
+    return {
+        "contents": {
+            "singleColumnMusicWatchNextResultsRenderer": {
+                "tabbedRenderer": {
+                    "watchNextTabbedResultsRenderer": {
+                        "tabs": [
+                            {"tabRenderer": {"title": "Queue"}},
+                            lyrics_tab,
+                            related_tab,
+                        ]
+                    }
+                }
+            }
+        }
+    }


### PR DESCRIPTION
## Summary

- Add YTMusic `song_get_lyric` support and return FeelUOwn `LyricModel` content.
- Move lyrics-specific watch response parsing and LRC conversion into `fuo_ytmusic.lyrics` to keep `service.py` focused on client/API orchestration.
- Fetch the lyrics tab browse id from the raw watch `next` response and request timestamped lyrics with an anonymous lyrics client.
- Convert timestamped lyrics to LRC and return `None` only when YTMusic provides no lyrics browse id or only plain-text lyrics; API/schema errors now propagate instead of being hidden.
- Cover provider/service behavior, timestamp conversion, anonymous-client usage, concurrent lazy initialization, and a manual end-to-end workflow.

## Testing

- `.venv/bin/python -m pytest`
- `.venv/bin/ruff check fuo_ytmusic/lyrics.py fuo_ytmusic/service.py fuo_ytmusic/provider.py tests/test_lyrics.py tests/test_service.py tests/test_provider_song_get.py manual_tests/lyrics_e2e_test.py`
- `.venv/bin/ruff format --check fuo_ytmusic/lyrics.py fuo_ytmusic/service.py fuo_ytmusic/provider.py tests/test_lyrics.py tests/test_service.py tests/test_provider_song_get.py manual_tests/lyrics_e2e_test.py`
- `git diff --check`
- `YTMUSIC_MANUAL_PROXY=http://127.0.0.1:7890 YTMUSIC_MANUAL_TIMEOUT=12 .venv/bin/python -m pytest manual_tests/lyrics_e2e_test.py -s --run-manual-tests`

Note: `.venv/bin/ruff check .` still reports the pre-existing import-order issue in `tests/test_headerfile.py`.
